### PR TITLE
Fix build errors and crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dts-gen",
-  "version": "0.4.20",
+  "version": "0.5.0",
   "description": "TypeScript Definition File Generator",
   "main": "bin/lib/index.js",
   "bin": {
@@ -42,5 +42,8 @@
   "bugs": {
     "url": "https://github.com/Microsoft/dts-gen/issues"
   },
-  "homepage": "https://github.com/Microsoft/dts-gen#readme"
+  "homepage": "https://github.com/Microsoft/dts-gen#readme",
+  "engines": {
+    "node": ">=6.0.0"
+  }
 }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -15,8 +15,8 @@ class MyClass {
 	constructor(public arg: number) {
 
 	}
-	prototypeMethod(p: any) { }
-	static staticMethod(s: any) { }
+	prototypeMethod(_p: any) { }
+	static staticMethod(_s: any) { }
 	static staticNum = 32;
 	instanceStr = 'inst';
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,11 @@
             "dom"
         ],
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "noImplicitAny": true,
         "strictNullChecks": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
         "sourceMap": false,
         "outDir": "./bin",
         "newLine": "LF"


### PR DESCRIPTION
Fixes #19,  #21, and #33

* Cannot subclass Error unless target is ES6
* A type may not be named `object`. I'm not sure what this type is for, so named it `ObjectLike`.
* Some `--strictNullChecks` errors
* Remove unused functions