### PR TITLE
Remove "source-map-support"

### DIFF
--- a/lib/run.ts
+++ b/lib/run.ts
@@ -5,8 +5,6 @@ import writeDefinitelyTypedPackage from './definitely-typed';
 import * as yargs from 'yargs';
 import * as fs from 'fs';
 import * as path from 'path';
-import { install } from 'source-map-support';
-install();
 
 const templatesDirectory = path.join(__dirname, "..", "..", "templates");
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "dts-dom": "latest",
-    "typescript": "^2.1.4",
+    "typescript": "^2.2.0",
     "underscore": "^1.8.3",
     "yargs": "^4.8.1"
   },


### PR DESCRIPTION
Accidentally left this in. It isn't in "package.json", so if someone didn't have it installed globally, that would be a problem.
Also, upgrade `tsc` to support `object`.