### PR TITLE
`e instanceof ArgsError` is always false

### DIFF
--- a/lib/run.ts
+++ b/lib/run.ts
@@ -42,6 +42,7 @@ const args: Options = yargs
 class ArgsError extends Error {
 	constructor(public argsError: string) {
 		super();
+		Object.setPrototypeOf(this, ArgsError.prototype);
 	}
 }
 


### PR DESCRIPTION
See: https://github.com/Microsoft/TypeScript/wiki/FAQ#why-doesnt-extending-built-ins-like-error-array-and-map-work