### PR TITLE
Add required dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "dts-dom": "latest",
+    "source-map-support": "^0.4.14",
     "typescript": "^2.2.0",
     "underscore": "^1.8.3",
     "yargs": "^4.8.1"


### PR DESCRIPTION
This package requires `source-map-support` which is currently not added as a dependency.

Fixes #44 and other crash related issues.
