### PR TITLE
Add support for expressions from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ An arbitrary expression to generate a file for.
 By default, this will be assigned to the name `dts_gen_expr` and generated as `dts_gen_expr.d.ts`.
 You can use the `-name` parameter to change this.
 
+#### `--expression-file`
+
+Example: `--expression-file "expressions.js"`
+##### expressions.js
+```js
+var fs = require('fs');
+fs.lstatSync('.');
+```
+
+A file containing arbitrary expression to generate a file for.
+The file will be named `${basename}.d.ts`, i.e. `expressions.d.ts`.
+The contents of the file will be `eval`'d, and the last statement in the file will be the value used.
+
 #### `--name` (`-n`)
 
 Example: `--name MyVar`

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -11,6 +11,7 @@ const templatesDirectory = path.join(__dirname, "..", "..", "templates");
 interface Options {
 	module?: string;
 	expression?: string;
+	'expression-file': string;
 	identifier?: string;
 	template?: string;
 
@@ -57,7 +58,7 @@ try {
 	if (+!!args.dt + +!!args.file + +!!args.stdout > 1) {
 		throw new ArgsError('Cannot specify more than one output mode');
 	}
-	if (+!!args.identifier + +!!args.expression + +!!args.module  + +!!args.template!== 1) {
+	if (+!!args.identifier + +!!args.expression + +!!args.module + +!!args['expression-file']  + +!!args.template!== 1) {
 		throw new ArgsError('Must specify exactly one input');
 	}
 	if (typeof args.name === 'boolean') throw new ArgsError('Must specify a value for "-name"');
@@ -74,6 +75,13 @@ try {
 	} else if (args.expression) {
 		name = args.name || 'dts_gen_expr';
 		result = guess.generateIdentifierDeclarationFile(name, eval(args.expression));
+	} else if (args['expression-file']) {
+		if (args.name) throw new ArgsError('Cannot use -name with -expression-file');
+		const filename = args['expression-file'];
+		name = path.basename(filename, path.extname(filename)).replace(/[^A-Za-z0-9]/g, '_');
+		(module as any).paths.unshift(process.cwd() + '/node_modules');
+		const fileContent = fs.readFileSync(filename, "utf-8");
+		result = guess.generateIdentifierDeclarationFile(name, eval(fileContent));
 	} else if (args.identifier) {
 		if (args.name) throw new ArgsError('Cannot use -name with -identifier');
 		if (args.module || args.expression) throw new ArgsError('Cannot specify more than one input');


### PR DESCRIPTION
Some modules has the useful types hidden under a function call (for setting options, making connections, etc.) so the module export doesn't work very well.
The eval mode is very handy in those cases, but writing longer expressions on the command line is annoying.

The user will of course have to make some adjustments to the exported types but I had great success when I tried it out on the https://github.com/rtc-io/rtc-quickconnect module.