### PR TITLE
Update tslint extends path

### DIFF
--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -26,7 +26,7 @@ async function run(indexDtsContent: string, packageName: string): Promise<void> 
 		["index.d.ts", await getIndex(indexDtsContent, packageName)],
 		[`${packageName}-tests.ts`, ""],
 		["tsconfig.json", `${JSON.stringify(getTSConfig(packageName), undefined, 4)}\n`],
-		["tslint.json", '{ "extends": "../tslint.json" }\n'],
+		["tslint.json", '{ "extends": "dtslint/dt.json" }\n'],
 	]
 
 	for (const [name, text] of files) {


### PR DESCRIPTION
Add proper tslint extends path.

Defined here: https://github.com/DefinitelyTyped/DefinitelyTyped#lint

```typescript
{
    "extends": "dtslint/dt.json",
    "rules": {
        // This package uses the Function type, and it will take effort to fix.
        "ban-types": false
    }
}
```