### PR TITLE
Fix typo in overwrite error message

### DIFF
--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -9,7 +9,7 @@ export default function writeDefinitelyTypedPackage(
 	// Check for overwrite
 	if (!overwrite) {
 		if (existsSync(packageDir)) {
-			console.log(`Directory ${packageDir} already exists and -overwrite was not specified; exiting.`);
+			console.log(`Directory ${packageDir} already exists and --overwrite was not specified; exiting.`);
 			process.exit(2);
 		}
 	}


### PR DESCRIPTION
Original:
`Directory types\jquery already exists and -overwrite was not specified; exiting.`
Fixed:
`Directory types\jquery already exists and --overwrite was not specified; exiting.`

Also, running `dts-gen -overwrite` returns the version number. I'm guessing that's a separate issue.