### PR TITLE
Auto-detect author's name and GitHub URL

### DIFF
--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { get, STATUS_CODES } from "http";
 import { homedir } from 'os';
-const parseGitConfig = require('parse-git-config');
+import parseGitConfig = require('parse-git-config');
 import { join as joinPaths } from "path";
 import { format as formatUrl, parse as parseUrl } from 'url';
 

--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -1,6 +1,9 @@
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { get, STATUS_CODES } from "http";
+import { homedir } from 'os';
+const parseGitConfig = require('parse-git-config');
 import { join as joinPaths } from "path";
+import { format as formatUrl, parse as parseUrl } from 'url';
 
 export default function writeDefinitelyTypedPackage(
 		indexDtsContent: string, packageName: string, overwrite: boolean): void {
@@ -56,9 +59,37 @@ async function getHeader(packageName: string): Promise<string> {
 		console.warn(`Warning: Could not retrieve version/homepage information: ${e.message}`);
 	}
 
+	let authorName = 'My Self';
+	try {
+		const globalGitConfig = parseGitConfig.sync({ cwd: homedir(), path: '.gitconfig' });
+		if (globalGitConfig.user && globalGitConfig.user.name) {
+			authorName = globalGitConfig.user.name;
+		}
+	} catch (e) {
+		console.warn(`Warning: Could not retrieve author name: ${e.message}`);
+	}
+
+	let authorUserName = 'me';
+	try {
+		const repoGitConfig = parseGitConfig.sync({ path: joinPaths('.git', 'config') });
+		if (repoGitConfig['remote "origin"'] && repoGitConfig['remote "origin"'].url) {
+			const url = parseUrl(repoGitConfig['remote "origin"'].url);
+			if (url.hostname === 'github.com' && url.pathname) {
+				authorUserName = url.pathname.split('/')[1] || authorUserName;
+			}
+		}
+	} catch (e) {
+		console.warn(`Warning: Could not retrieve author's user name: ${e.message}`);
+	}
+	const authorUrl = formatUrl({
+		protocol: 'https',
+		hostname: 'github.com',
+		pathname: authorUserName,
+	});
+
 	return `// Type definitions for ${packageName} ${version}
 // Project: ${project}
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: ${authorName} <${authorUrl}>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`;
 }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/mocha": "latest",
     "@types/node": "latest",
+    "@types/parse-git-config": "^1.1.0",
     "@types/yargs": "latest",
     "ecurve": "1.0.5",
     "jquery": "latest",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "dts-dom": "latest",
+    "parse-git-config": "^1.1.1",
     "typescript": "^2.2.0",
     "yargs": "^4.8.1"
   },


### PR DESCRIPTION
This PR adds support for auto-detecting an author's name and GitHub URL when generating a header. It looks at `~/.gitconfig` for the author's name and `.git/config` for the author's GitHub URL.

~~**Note**: Type definitions for `parse-git-config` weren't available at the time of the PR. They can be added when https://github.com/DefinitelyTyped/DefinitelyTyped/pull/16817 is merged.~~