### PR TITLE
Fix crash when types directory does not exist

### DIFF
--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -1,5 +1,6 @@
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, writeFileSync } from 'fs';
 import { get, STATUS_CODES } from "http";
+import mkdirp = require('mkdirp');
 import { join as joinPaths } from "path";
 
 export default function writeDefinitelyTypedPackage(
@@ -15,7 +16,7 @@ export default function writeDefinitelyTypedPackage(
 	}
 
 	if (!existsSync(packageDir)) {
-		mkdirSync(packageDir);
+		mkdirp.sync(packageDir);
 	}
 
 	run(indexDtsContent, packageName, packageDir).catch(e => {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
   },
   "dependencies": {
     "dts-dom": "latest",
+    "mkdirp": "^0.5.1",
     "typescript": "^2.2.0",
     "yargs": "^4.8.1"
   },
   "devDependencies": {
+    "@types/mkdirp": "^0.3.29",
     "@types/mocha": "latest",
     "@types/node": "latest",
     "@types/yargs": "latest",


### PR DESCRIPTION
This PR fixes `dts-gen` crashing when the `types` directory does not exist.

---

`dts-gen` crashes when used with the `--dt` argument and the `types` subdirectory does not exist. This can happen if you run `dts-gen --dt` anywhere besides the root of the DefinitelyTyped repo.
```
"C:\Program Files (x86)\nodejs\node.exe" --inspect-brk=55971 S:\Projects\_GitHub\dts-gen\bin\lib\run.js --dt --name angular-tooltips --template module --overwrite
Unexpected crash! Please log a bug with the commandline you specified.
S:\Projects\_GitHub\dts-gen\bin\lib\run.js:130
        throw e;
        ^

Error: ENOENT: no such file or directory, mkdir 'S:\Projects\_GitHub\dts-gen\types\angular-tooltips'
    at Object.fs.mkdirSync (fs.js:895:18)
    at Object.writeDefinitelyTypedPackage [as default] (S:\Projects\_GitHub\dts-gen\bin\lib\definitely-typed.js:24:14)
    at Object.<anonymous> (S:\Projects\_GitHub\dts-gen\bin\lib\run.js:92:35)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:427:7)
```