### PR TITLE
Allow scoped packages

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,7 +21,13 @@ const builtins: { [name: string]: (new (...args: any[]) => any) | undefined } = 
 
 function forceAsIdentifier(s: string): string {
 	// TODO: Make this more comprehensive
-	return s.replace(/-/g, '_');
+	let ret = s.replace(/-/g, '_');
+	if (s.indexOf('@') === 0 && s.indexOf('/') !== -1) {
+		// we have a scoped module, e.g. @bla/foo
+		// which should be converted to   bla__foo
+		ret = ret.substr(1).replace('/', '__');
+	}
+	return ret;
 }
 
 function getValueTypes(value: any): ValueTypes {


### PR DESCRIPTION
Local identifiers for scoped packages follow a specific pattern.
`@some/module` becomes `some__module`.

Currently this fails:
```
➜  DefinitelyTyped git:(master) ✗ dts-gen --dt --name "@storybook/addon-actions" --template module
Unexpected crash! Please log a bug with the commandline you specified.
/Users/joscha/.config/yarn/global/node_modules/dts-gen/bin/lib/run.js:130
        throw e;
        ^

Error: ENOENT: no such file or directory, mkdir 'types/@storybook/addon-actions'
    at Object.fs.mkdirSync (fs.js:855:18)
    at Object.writeDefinitelyTypedPackage [as default] (/Users/joscha/.config/yarn/global/node_modules/dts-gen/bin/lib/definitely-typed.js:24:14)
    at Object.<anonymous> (/Users/joscha/.config/yarn/global/node_modules/dts-gen/bin/lib/run.js:92:35)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:418:7)
```

closes #55 
references https://github.com/Microsoft/dtslint/pull/47, https://github.com/DefinitelyTyped/dt-review-tool/pull/11
detected whilst working on https://github.com/storybooks/storybook/issues/1166