### PR TITLE
fix: use ret to check before modifying

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,7 +22,7 @@ const builtins: { [name: string]: (new (...args: any[]) => any) | undefined } = 
 function forceAsIdentifier(s: string): string {
 	// TODO: Make this more comprehensive
 	let ret = s.replace(/-/g, '_');
-	if (s.indexOf('@') === 0 && s.indexOf('/') !== -1) {
+	if (ret.indexOf('@') === 0 && ret.indexOf('/') !== -1) {
 		// we have a scoped module, e.g. @bla/foo
 		// which should be converted to   bla__foo
 		ret = ret.substr(1).replace('/', '__');


### PR DESCRIPTION
This is not a problem right now, as there are no other transformations on `s`, but if the code changes in the future and this is overlooked, it might cause problems.

Sorry about that.

follow-up to #63 
