### PR TITLE
Add strictFunctionTypes to template

### DIFF
--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -100,6 +100,7 @@ function getTSConfig(packageName: string): {} {
 			lib: ["es6"],
 			noImplicitAny: true,
 			noImplicitThis: true,
+			strictFunctionTypes: true,
 			strictNullChecks: true,
 			baseUrl: "../",
 			typeRoots: ["../"],


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/PULL_REQUEST_TEMPLATE.md
says it should be present