### PR TITLE
Add "prototype" to list of non-visitable names

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -103,7 +103,7 @@ function getKeysOfObject(obj: object) {
 }
 
 function isVisitableName(s: string) {
-	return (s[0] !== '_') && (["caller", "arguments", "constructor", "super_"].indexOf(s) < 0);
+	return (s[0] !== '_') && (["caller", "arguments", "constructor", "super_", "prototype"].indexOf(s) < 0);
 }
 
 function isLegalIdentifier(s: string) {


### PR DESCRIPTION
This prevents unnecessary prototype definitions and fixes: https://github.com/Microsoft/dts-gen/issues/78, https://github.com/Microsoft/dts-gen/issues/70 and https://github.com/Microsoft/dts-gen/issues/67