### PR TITLE
Cleanup for 0.5.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 bin/
 npm-debug.log
+.vscode/
 

--- a/baselines/expr-Math.d.ts
+++ b/baselines/expr-Math.d.ts
@@ -1,45 +1,89 @@
 declare namespace Math {
     const E: number;
+
     const LN10: number;
+
     const LN2: number;
+
     const LOG10E: number;
+
     const LOG2E: number;
+
     const PI: number;
+
     const SQRT1_2: number;
+
     const SQRT2: number;
+
     function abs(p0: any): any;
+
     function acos(p0: any): any;
+
     function acosh(p0: any): any;
+
     function asin(p0: any): any;
+
     function asinh(p0: any): any;
+
     function atan(p0: any): any;
+
     function atan2(p0: any, p1: any): any;
+
     function atanh(p0: any): any;
+
     function cbrt(p0: any): any;
+
     function ceil(p0: any): any;
+
     function clz32(p0: any): any;
+
     function cos(p0: any): any;
+
     function cosh(p0: any): any;
+
     function exp(p0: any): any;
+
     function expm1(p0: any): any;
+
     function floor(p0: any): any;
+
     function fround(p0: any): any;
+
     function hypot(p0: any, p1: any): any;
+
     function imul(p0: any, p1: any): any;
+
     function log(p0: any): any;
+
     function log10(p0: any): any;
+
     function log1p(p0: any): any;
+
     function log2(p0: any): any;
+
     function max(p0: any, p1: any): any;
+
     function min(p0: any, p1: any): any;
+
     function pow(p0: any, p1: any): any;
+
     function random(): any;
+
     function round(p0: any): any;
+
     function sign(p0: any): any;
+
     function sin(p0: any): any;
+
     function sinh(p0: any): any;
+
     function sqrt(p0: any): any;
+
     function tan(p0: any): any;
+
     function tanh(p0: any): any;
+
     function trunc(p0: any): any;
+
 }
+

--- a/baselines/expr-badNames.d.ts
+++ b/baselines/expr-badNames.d.ts
@@ -4,3 +4,4 @@ declare const badNames: {
     default: boolean;
     with: number;
 };
+

--- a/baselines/expr-builtIns.d.ts
+++ b/baselines/expr-builtIns.d.ts
@@ -2,3 +2,4 @@ declare const builtIns: {
     arr: string[];
     d: Date;
 };
+

--- a/baselines/expr-selfref.d.ts
+++ b/baselines/expr-selfref.d.ts
@@ -3,3 +3,4 @@ declare const selfref: {
     b: string;
     self: any;
 };
+

--- a/baselines/expr-someArray.d.ts
+++ b/baselines/expr-someArray.d.ts
@@ -1,1 +1,2 @@
 declare const someArray: number[];
+

--- a/baselines/expr-someClass.d.ts
+++ b/baselines/expr-someClass.d.ts
@@ -1,6 +1,11 @@
 declare class someClass {
-    constructor(arg: any);
-    prototypeMethod(p: any): void;
-    static staticMethod(s: any): void;
+    constructor(...args: any[]);
+
+    prototypeMethod(...args: any[]): void;
+
+    static staticMethod(...args: any[]): void;
+
     static staticNum: number;
+
 }
+

--- a/baselines/module-ecurve.d.ts
+++ b/baselines/module-ecurve.d.ts
@@ -1,21 +1,40 @@
 export class Curve {
     constructor(p: any, a: any, b: any, Gx: any, Gy: any, n: any, h: any);
+
     isInfinity(Q: any): any;
+
     isOnCurve(Q: any): any;
+
     pointFromX(isOdd: any, x: any): any;
+
     validate(Q: any): any;
+
 }
+
 export class Point {
     constructor(curve: any, x: any, y: any, z: any);
+
     add(b: any): any;
+
     equals(other: any): any;
+
     getEncoded(compressed: any): any;
+
     multiply(k: any): any;
+
     multiplyTwo(j: any, x: any, k: any): any;
+
     negate(): any;
+
     toString(): any;
+
     twice(): any;
+
     static decodeFrom(curve: any, buffer: any): any;
+
     static fromAffine(curve: any, x: any, y: any): any;
+
 }
+
 export function getCurveByName(name: any): any;
+

--- a/baselines/module-fs.d.ts
+++ b/baselines/module-fs.d.ts
@@ -1,132 +1,345 @@
+export class Dirent {
+    constructor(...args: any[]);
+
+    isBlockDevice(...args: any[]): void;
+
+    isCharacterDevice(...args: any[]): void;
+
+    isDirectory(...args: any[]): void;
+
+    isFIFO(...args: any[]): void;
+
+    isFile(...args: any[]): void;
+
+    isSocket(...args: any[]): void;
+
+    isSymbolicLink(...args: any[]): void;
+
+}
+
 export class FileReadStream {
     constructor(path: any, options: any);
-    close(cb: any): any;
-    destroy(): void;
+
+    close(cb: any): void;
+
     open(): void;
+
 }
+
 export class FileWriteStream {
     constructor(path: any, options: any);
-    close(cb: any): any;
-    destroy(): void;
-    destroySoon(chunk: any, encoding: any, cb: any): void;
+
+    close(cb: any): void;
+
+    destroySoon(chunk: any, encoding: any, cb: any): any;
+
     open(): void;
+
 }
+
 export class ReadStream {
     constructor(path: any, options: any);
-    close(cb: any): any;
-    destroy(): void;
+
+    close(cb: any): void;
+
     open(): void;
+
 }
+
 export class Stats {
     constructor(dev: any, mode: any, nlink: any, uid: any, gid: any, rdev: any, blksize: any, ino: any, size: any, blocks: any, atim_msec: any, mtim_msec: any, ctim_msec: any, birthtim_msec: any);
+
     isBlockDevice(): any;
+
     isCharacterDevice(): any;
+
     isDirectory(): any;
+
     isFIFO(): any;
+
     isFile(): any;
+
     isSocket(): any;
+
     isSymbolicLink(): any;
+
 }
-export class SyncWriteStream {
-    constructor(fd: any, options: any);
-    destroy(): any;
-    destroySoon(): any;
-}
+
 export class WriteStream {
     constructor(path: any, options: any);
-    close(cb: any): any;
-    destroy(): void;
-    destroySoon(chunk: any, encoding: any, cb: any): void;
+
+    close(cb: any): void;
+
+    destroySoon(chunk: any, encoding: any, cb: any): any;
+
     open(): void;
+
 }
+
 export const F_OK: number;
+
 export const R_OK: number;
+
 export const W_OK: number;
+
 export const X_OK: number;
+
 export const constants: {
+    COPYFILE_EXCL: number;
+    COPYFILE_FICLONE: number;
+    COPYFILE_FICLONE_FORCE: number;
     F_OK: number;
     O_APPEND: number;
     O_CREAT: number;
+    O_DIRECT: number;
+    O_DIRECTORY: number;
+    O_DSYNC: number;
     O_EXCL: number;
+    O_NOATIME: number;
+    O_NOCTTY: number;
+    O_NOFOLLOW: number;
+    O_NONBLOCK: number;
     O_RDONLY: number;
     O_RDWR: number;
+    O_SYNC: number;
     O_TRUNC: number;
     O_WRONLY: number;
     R_OK: number;
+    S_IFBLK: number;
     S_IFCHR: number;
     S_IFDIR: number;
+    S_IFIFO: number;
     S_IFLNK: number;
     S_IFMT: number;
     S_IFREG: number;
+    S_IFSOCK: number;
+    S_IRGRP: number;
+    S_IROTH: number;
+    S_IRUSR: number;
+    S_IRWXG: number;
+    S_IRWXO: number;
+    S_IRWXU: number;
+    S_IWGRP: number;
+    S_IWOTH: number;
+    S_IWUSR: number;
+    S_IXGRP: number;
+    S_IXOTH: number;
+    S_IXUSR: number;
+    UV_DIRENT_BLOCK: number;
+    UV_DIRENT_CHAR: number;
+    UV_DIRENT_DIR: number;
+    UV_DIRENT_FIFO: number;
+    UV_DIRENT_FILE: number;
+    UV_DIRENT_LINK: number;
+    UV_DIRENT_SOCKET: number;
+    UV_DIRENT_UNKNOWN: number;
+    UV_FS_COPYFILE_EXCL: number;
+    UV_FS_COPYFILE_FICLONE: number;
+    UV_FS_COPYFILE_FICLONE_FORCE: number;
+    UV_FS_SYMLINK_DIR: number;
+    UV_FS_SYMLINK_JUNCTION: number;
     W_OK: number;
     X_OK: number;
 };
+
+export const lchmod: any;
+
+export const lchmodSync: any;
+
 export function access(path: any, mode: any, callback: any): void;
+
 export function accessSync(path: any, mode: any): void;
-export function appendFile(path: any, data: any, options: any, callback_: any, ...args: any[]): void;
+
+export function appendFile(path: any, data: any, options: any, callback: any): void;
+
 export function appendFileSync(path: any, data: any, options: any): void;
+
 export function chmod(path: any, mode: any, callback: any): void;
-export function chmodSync(path: any, mode: any): any;
+
+export function chmodSync(path: any, mode: any): void;
+
 export function chown(path: any, uid: any, gid: any, callback: any): void;
-export function chownSync(path: any, uid: any, gid: any): any;
+
+export function chownSync(path: any, uid: any, gid: any): void;
+
 export function close(fd: any, callback: any): void;
-export function closeSync(fd: any): any;
+
+export function closeSync(fd: any): void;
+
+export function copyFile(src: any, dest: any, flags: any, callback: any): void;
+
+export function copyFileSync(src: any, dest: any, flags: any): void;
+
 export function createReadStream(path: any, options: any): any;
+
 export function createWriteStream(path: any, options: any): any;
-export function exists(path: any, callback: any): void;
+
+export function exists(path: any, callback: any): any;
+
 export function existsSync(path: any): any;
+
 export function fchmod(fd: any, mode: any, callback: any): void;
-export function fchmodSync(fd: any, mode: any): any;
+
+export function fchmodSync(fd: any, mode: any): void;
+
 export function fchown(fd: any, uid: any, gid: any, callback: any): void;
-export function fchownSync(fd: any, uid: any, gid: any): any;
+
+export function fchownSync(fd: any, uid: any, gid: any): void;
+
 export function fdatasync(fd: any, callback: any): void;
-export function fdatasyncSync(fd: any): any;
-export function fstat(fd: any, callback: any): void;
-export function fstatSync(fd: any): any;
+
+export function fdatasyncSync(fd: any): void;
+
+export function fstat(fd: any, options: any, callback: any): void;
+
+export function fstatSync(fd: any, options: any): any;
+
 export function fsync(fd: any, callback: any): void;
-export function fsyncSync(fd: any): any;
+
+export function fsyncSync(fd: any): void;
+
 export function ftruncate(fd: any, len: any, callback: any): void;
-export function ftruncateSync(fd: any, len: any): any;
+
+export function ftruncateSync(fd: any, len: any): void;
+
 export function futimes(fd: any, atime: any, mtime: any, callback: any): void;
+
 export function futimesSync(fd: any, atime: any, mtime: any): void;
-export function link(srcpath: any, dstpath: any, callback: any): void;
-export function linkSync(srcpath: any, dstpath: any): any;
-export function lstat(path: any, callback: any): void;
-export function lstatSync(path: any): any;
-export function mkdir(path: any, mode: any, callback: any): void;
-export function mkdirSync(path: any, mode: any): any;
+
+export function lchown(path: any, uid: any, gid: any, callback: any): void;
+
+export function lchownSync(path: any, uid: any, gid: any): void;
+
+export function link(existingPath: any, newPath: any, callback: any): void;
+
+export function linkSync(existingPath: any, newPath: any): any;
+
+export function lstat(path: any, options: any, callback: any): void;
+
+export function lstatSync(path: any, options: any): any;
+
+export function mkdir(path: any, options: any, callback: any): void;
+
+export function mkdirSync(path: any, options: any): void;
+
 export function mkdtemp(prefix: any, options: any, callback: any): void;
+
 export function mkdtempSync(prefix: any, options: any): any;
-export function open(path: any, flags: any, mode: any, callback_: any, ...args: any[]): void;
+
+export function open(path: any, flags: any, mode: any, callback: any, ...args: any[]): void;
+
 export function openSync(path: any, flags: any, mode: any): any;
-export function read(fd: any, buffer: any, offset: any, length: any, position: any, callback: any, ...args: any[]): any;
-export function readFile(path: any, options: any, callback_: any, ...args: any[]): void;
+
+export function read(fd: any, buffer: any, offset: any, length: any, position: any, callback: any): any;
+
+export function readFile(path: any, options: any, callback: any): void;
+
 export function readFileSync(path: any, options: any): any;
-export function readSync(fd: any, buffer: any, offset: any, length: any, position: any, ...args: any[]): any;
+
+export function readSync(fd: any, buffer: any, offset: any, length: any, position: any): any;
+
 export function readdir(path: any, options: any, callback: any): void;
+
 export function readdirSync(path: any, options: any): any;
+
 export function readlink(path: any, options: any, callback: any): void;
+
 export function readlinkSync(path: any, options: any): any;
+
 export function realpath(p: any, options: any, callback: any): any;
+
 export function realpathSync(p: any, options: any): any;
+
 export function rename(oldPath: any, newPath: any, callback: any): void;
-export function renameSync(oldPath: any, newPath: any): any;
+
+export function renameSync(oldPath: any, newPath: any): void;
+
 export function rmdir(path: any, callback: any): void;
-export function rmdirSync(path: any): any;
-export function stat(path: any, callback: any): void;
-export function statSync(path: any): any;
+
+export function rmdirSync(path: any): void;
+
+export function stat(path: any, options: any, callback: any): void;
+
+export function statSync(path: any, options: any): any;
+
 export function symlink(target: any, path: any, type_: any, callback_: any, ...args: any[]): void;
-export function symlinkSync(target: any, path: any, type: any): any;
+
+export function symlinkSync(target: any, path: any, type: any): void;
+
 export function truncate(path: any, len: any, callback: any): any;
+
 export function truncateSync(path: any, len: any): any;
+
 export function unlink(path: any, callback: any): void;
-export function unlinkSync(path: any): any;
+
+export function unlinkSync(path: any): void;
+
 export function unwatchFile(filename: any, listener: any): void;
+
 export function utimes(path: any, atime: any, mtime: any, callback: any): void;
+
 export function utimesSync(path: any, atime: any, mtime: any): void;
+
 export function watch(filename: any, options: any, listener: any): any;
+
 export function watchFile(filename: any, options: any, listener: any): any;
+
 export function write(fd: any, buffer: any, offset: any, length: any, position: any, callback: any): any;
-export function writeFile(path: any, data: any, options: any, callback_: any, ...args: any[]): void;
+
+export function writeFile(path: any, data: any, options: any, callback: any): void;
+
 export function writeFileSync(path: any, data: any, options: any): void;
+
 export function writeSync(fd: any, buffer: any, offset: any, length: any, position: any): any;
+
+export namespace promises {
+    function access(path: any, mode: any): any;
+
+    function appendFile(path: any, data: any, options: any): any;
+
+    function chmod(path: any, mode: any): any;
+
+    function chown(path: any, uid: any, gid: any): any;
+
+    function copyFile(src: any, dest: any, flags: any): any;
+
+    function lchmod(path: any, mode: any): any;
+
+    function lchown(path: any, uid: any, gid: any): any;
+
+    function link(existingPath: any, newPath: any): any;
+
+    function lstat(path: any, options: any): any;
+
+    function mkdir(path: any, options: any): any;
+
+    function mkdtemp(prefix: any, options: any): any;
+
+    function open(path: any, flags: any, mode: any, ...args: any[]): any;
+
+    function readFile(path: any, options: any): any;
+
+    function readdir(path: any, options: any): any;
+
+    function readlink(path: any, options: any): any;
+
+    function realpath(path: any, options: any): any;
+
+    function rename(oldPath: any, newPath: any): any;
+
+    function rmdir(path: any): any;
+
+    function stat(path: any, options: any): any;
+
+    function symlink(target: any, path: any, type_: any): any;
+
+    function truncate(path: any, len: any): any;
+
+    function unlink(path: any): any;
+
+    function utimes(path: any, atime: any, mtime: any): any;
+
+    function writeFile(path: any, data: any, options: any): any;
+
+}
+

--- a/baselines/module-jquery.d.ts
+++ b/baselines/module-jquery.d.ts
@@ -1,2 +1,4 @@
 export = jquery;
+
 declare function jquery(w: any): any;
+

--- a/baselines/module-lodash.d.ts
+++ b/baselines/module-lodash.d.ts
@@ -1,580 +1,1156 @@
 export = lodash;
+
 declare class lodash {
     constructor(...args: any[]);
+
     add(...args: any[]): any;
+
     after(...args: any[]): any;
+
     ary(...args: any[]): any;
+
     assign(...args: any[]): any;
+
     assignIn(...args: any[]): any;
+
     assignInWith(...args: any[]): any;
+
     assignWith(...args: any[]): any;
+
     at(paths: any): any;
+
     attempt(...args: any[]): any;
+
     before(...args: any[]): any;
+
     bind(...args: any[]): any;
+
     bindAll(...args: any[]): any;
+
     bindKey(...args: any[]): any;
+
     camelCase(...args: any[]): any;
+
     capitalize(...args: any[]): any;
+
     castArray(...args: any[]): any;
+
     ceil(...args: any[]): any;
+
     chain(): any;
+
     chunk(...args: any[]): any;
+
     clamp(...args: any[]): any;
+
     clone(...args: any[]): any;
+
     cloneDeep(...args: any[]): any;
+
     cloneDeepWith(...args: any[]): any;
+
     cloneWith(...args: any[]): any;
+
     commit(): any;
+
     compact(...args: any[]): any;
+
     concat(...args: any[]): any;
+
     cond(...args: any[]): any;
+
     conforms(...args: any[]): any;
+
     conformsTo(...args: any[]): any;
+
     constant(...args: any[]): any;
+
     countBy(...args: any[]): any;
+
     create(...args: any[]): any;
+
     curry(...args: any[]): any;
+
     curryRight(...args: any[]): any;
+
     debounce(...args: any[]): any;
+
     deburr(...args: any[]): any;
+
     defaultTo(...args: any[]): any;
+
     defaults(...args: any[]): any;
+
     defaultsDeep(...args: any[]): any;
+
     defer(...args: any[]): any;
+
     delay(...args: any[]): any;
+
     difference(...args: any[]): any;
+
     differenceBy(...args: any[]): any;
+
     differenceWith(...args: any[]): any;
+
     divide(...args: any[]): any;
+
     drop(...args: any[]): any;
+
     dropRight(...args: any[]): any;
+
     dropRightWhile(...args: any[]): any;
+
     dropWhile(...args: any[]): any;
+
     each(...args: any[]): any;
+
     eachRight(...args: any[]): any;
+
     endsWith(...args: any[]): any;
+
     entries(...args: any[]): any;
+
     entriesIn(...args: any[]): any;
+
     eq(...args: any[]): any;
+
     escape(...args: any[]): any;
+
     escapeRegExp(...args: any[]): any;
+
     every(...args: any[]): any;
+
     extend(...args: any[]): any;
+
     extendWith(...args: any[]): any;
+
     fill(...args: any[]): any;
+
     filter(...args: any[]): any;
+
     find(...args: any[]): any;
+
     findIndex(...args: any[]): any;
+
     findKey(...args: any[]): any;
+
     findLast(...args: any[]): any;
+
     findLastIndex(...args: any[]): any;
+
     findLastKey(...args: any[]): any;
+
     first(...args: any[]): any;
+
     flatMap(...args: any[]): any;
+
     flatMapDeep(...args: any[]): any;
+
     flatMapDepth(...args: any[]): any;
+
     flatten(...args: any[]): any;
+
     flattenDeep(...args: any[]): any;
+
     flattenDepth(...args: any[]): any;
+
     flip(...args: any[]): any;
+
     floor(...args: any[]): any;
+
     flow(...args: any[]): any;
+
     flowRight(...args: any[]): any;
+
     forEach(...args: any[]): any;
+
     forEachRight(...args: any[]): any;
+
     forIn(...args: any[]): any;
+
     forInRight(...args: any[]): any;
+
     forOwn(...args: any[]): any;
+
     forOwnRight(...args: any[]): any;
+
     fromPairs(...args: any[]): any;
+
     functions(...args: any[]): any;
+
     functionsIn(...args: any[]): any;
+
     get(...args: any[]): any;
+
     groupBy(...args: any[]): any;
+
     gt(...args: any[]): any;
+
     gte(...args: any[]): any;
+
     has(...args: any[]): any;
+
     hasIn(...args: any[]): any;
+
     head(...args: any[]): any;
+
     identity(...args: any[]): any;
+
     inRange(...args: any[]): any;
+
     includes(...args: any[]): any;
+
     indexOf(...args: any[]): any;
+
     initial(...args: any[]): any;
+
     intersection(...args: any[]): any;
+
     intersectionBy(...args: any[]): any;
+
     intersectionWith(...args: any[]): any;
+
     invert(...args: any[]): any;
+
     invertBy(...args: any[]): any;
+
     invoke(...args: any[]): any;
+
     invokeMap(...args: any[]): any;
+
     isArguments(...args: any[]): any;
+
     isArray(...args: any[]): any;
+
     isArrayBuffer(...args: any[]): any;
+
     isArrayLike(...args: any[]): any;
+
     isArrayLikeObject(...args: any[]): any;
+
     isBoolean(...args: any[]): any;
+
     isBuffer(...args: any[]): any;
+
     isDate(...args: any[]): any;
+
     isElement(...args: any[]): any;
+
     isEmpty(...args: any[]): any;
+
     isEqual(...args: any[]): any;
+
     isEqualWith(...args: any[]): any;
+
     isError(...args: any[]): any;
+
     isFinite(...args: any[]): any;
+
     isFunction(...args: any[]): any;
+
     isInteger(...args: any[]): any;
+
     isLength(...args: any[]): any;
+
     isMap(...args: any[]): any;
+
     isMatch(...args: any[]): any;
+
     isMatchWith(...args: any[]): any;
+
     isNaN(...args: any[]): any;
+
     isNative(...args: any[]): any;
+
     isNil(...args: any[]): any;
+
     isNull(...args: any[]): any;
+
     isNumber(...args: any[]): any;
+
     isObject(...args: any[]): any;
+
     isObjectLike(...args: any[]): any;
+
     isPlainObject(...args: any[]): any;
+
     isRegExp(...args: any[]): any;
+
     isSafeInteger(...args: any[]): any;
+
     isSet(...args: any[]): any;
+
     isString(...args: any[]): any;
+
     isSymbol(...args: any[]): any;
+
     isTypedArray(...args: any[]): any;
+
     isUndefined(...args: any[]): any;
+
     isWeakMap(...args: any[]): any;
+
     isWeakSet(...args: any[]): any;
+
     iteratee(...args: any[]): any;
+
     join(...args: any[]): any;
+
     kebabCase(...args: any[]): any;
+
     keyBy(...args: any[]): any;
+
     keys(...args: any[]): any;
+
     keysIn(...args: any[]): any;
+
     last(...args: any[]): any;
+
     lastIndexOf(...args: any[]): any;
+
     lowerCase(...args: any[]): any;
+
     lowerFirst(...args: any[]): any;
+
     lt(...args: any[]): any;
+
     lte(...args: any[]): any;
+
     map(...args: any[]): any;
+
     mapKeys(...args: any[]): any;
+
     mapValues(...args: any[]): any;
+
     matches(...args: any[]): any;
+
     matchesProperty(...args: any[]): any;
+
     max(...args: any[]): any;
+
     maxBy(...args: any[]): any;
+
     mean(...args: any[]): any;
+
     meanBy(...args: any[]): any;
+
     memoize(...args: any[]): any;
+
     merge(...args: any[]): any;
+
     mergeWith(...args: any[]): any;
+
     method(...args: any[]): any;
+
     methodOf(...args: any[]): any;
+
     min(...args: any[]): any;
+
     minBy(...args: any[]): any;
+
     mixin(...args: any[]): any;
+
     multiply(...args: any[]): any;
+
     negate(...args: any[]): any;
+
     next(): any;
+
     noConflict(...args: any[]): any;
+
     noop(...args: any[]): any;
+
     now(...args: any[]): any;
+
     nth(...args: any[]): any;
+
     nthArg(...args: any[]): any;
+
     omit(...args: any[]): any;
+
     omitBy(...args: any[]): any;
+
     once(...args: any[]): any;
+
     orderBy(...args: any[]): any;
+
     over(...args: any[]): any;
+
     overArgs(...args: any[]): any;
+
     overEvery(...args: any[]): any;
+
     overSome(...args: any[]): any;
+
     pad(...args: any[]): any;
+
     padEnd(...args: any[]): any;
+
     padStart(...args: any[]): any;
+
     parseInt(...args: any[]): any;
+
     partial(...args: any[]): any;
+
     partialRight(...args: any[]): any;
+
     partition(...args: any[]): any;
+
     pick(...args: any[]): any;
+
     pickBy(...args: any[]): any;
+
     plant(value: any): any;
+
     pop(...args: any[]): any;
+
     property(...args: any[]): any;
+
     propertyOf(...args: any[]): any;
+
     pull(...args: any[]): any;
+
     pullAll(...args: any[]): any;
+
     pullAllBy(...args: any[]): any;
+
     pullAllWith(...args: any[]): any;
+
     pullAt(...args: any[]): any;
+
     push(...args: any[]): any;
+
     random(...args: any[]): any;
+
     range(...args: any[]): any;
+
     rangeRight(...args: any[]): any;
+
     rearg(...args: any[]): any;
+
     reduce(...args: any[]): any;
+
     reduceRight(...args: any[]): any;
+
     reject(...args: any[]): any;
+
     remove(...args: any[]): any;
+
     repeat(...args: any[]): any;
+
     replace(...args: any[]): any;
+
     rest(...args: any[]): any;
+
     result(...args: any[]): any;
+
     reverse(): any;
+
     round(...args: any[]): any;
+
     runInContext(...args: any[]): any;
+
     sample(...args: any[]): any;
+
     sampleSize(...args: any[]): any;
+
     set(...args: any[]): any;
+
     setWith(...args: any[]): any;
+
     shift(...args: any[]): any;
+
     shuffle(...args: any[]): any;
+
     size(...args: any[]): any;
+
     slice(...args: any[]): any;
+
     snakeCase(...args: any[]): any;
+
     some(...args: any[]): any;
+
     sort(...args: any[]): any;
+
     sortBy(...args: any[]): any;
+
     sortedIndex(...args: any[]): any;
+
     sortedIndexBy(...args: any[]): any;
+
     sortedIndexOf(...args: any[]): any;
+
     sortedLastIndex(...args: any[]): any;
+
     sortedLastIndexBy(...args: any[]): any;
+
     sortedLastIndexOf(...args: any[]): any;
+
     sortedUniq(...args: any[]): any;
+
     sortedUniqBy(...args: any[]): any;
+
     splice(...args: any[]): any;
+
     split(...args: any[]): any;
+
     spread(...args: any[]): any;
+
     startCase(...args: any[]): any;
+
     startsWith(...args: any[]): any;
+
     stubArray(...args: any[]): any;
+
     stubFalse(...args: any[]): any;
+
     stubObject(...args: any[]): any;
+
     stubString(...args: any[]): any;
+
     stubTrue(...args: any[]): any;
+
     subtract(...args: any[]): any;
+
     sum(...args: any[]): any;
+
     sumBy(...args: any[]): any;
+
     tail(...args: any[]): any;
+
     take(...args: any[]): any;
+
     takeRight(...args: any[]): any;
+
     takeRightWhile(...args: any[]): any;
+
     takeWhile(...args: any[]): any;
+
     tap(...args: any[]): any;
+
     template(...args: any[]): any;
+
     throttle(...args: any[]): any;
+
     thru(...args: any[]): any;
+
     times(...args: any[]): any;
+
     toArray(...args: any[]): any;
+
     toFinite(...args: any[]): any;
+
     toInteger(...args: any[]): any;
+
     toJSON(): any;
+
     toLength(...args: any[]): any;
+
     toLower(...args: any[]): any;
+
     toNumber(...args: any[]): any;
+
     toPairs(...args: any[]): any;
+
     toPairsIn(...args: any[]): any;
+
     toPath(...args: any[]): any;
+
     toPlainObject(...args: any[]): any;
+
     toSafeInteger(...args: any[]): any;
+
     toString(...args: any[]): any;
+
     toUpper(...args: any[]): any;
+
     transform(...args: any[]): any;
+
     trim(...args: any[]): any;
+
     trimEnd(...args: any[]): any;
+
     trimStart(...args: any[]): any;
+
     truncate(...args: any[]): any;
+
     unary(...args: any[]): any;
+
     unescape(...args: any[]): any;
+
     union(...args: any[]): any;
+
     unionBy(...args: any[]): any;
+
     unionWith(...args: any[]): any;
+
     uniq(...args: any[]): any;
+
     uniqBy(...args: any[]): any;
+
     uniqWith(...args: any[]): any;
+
     uniqueId(...args: any[]): any;
+
     unset(...args: any[]): any;
+
     unshift(...args: any[]): any;
+
     unzip(...args: any[]): any;
+
     unzipWith(...args: any[]): any;
+
     update(...args: any[]): any;
+
     updateWith(...args: any[]): any;
+
     upperCase(...args: any[]): any;
+
     upperFirst(...args: any[]): any;
+
     value(): any;
+
     valueOf(): any;
+
     values(...args: any[]): any;
+
     valuesIn(...args: any[]): any;
+
     without(...args: any[]): any;
+
     words(...args: any[]): any;
+
     wrap(...args: any[]): any;
+
     xor(...args: any[]): any;
+
     xorBy(...args: any[]): any;
+
     xorWith(...args: any[]): any;
+
     zip(...args: any[]): any;
+
     zipObject(...args: any[]): any;
+
     zipObjectDeep(...args: any[]): any;
+
     zipWith(...args: any[]): any;
+
     static VERSION: string;
+
     static add(value: any, other: any): any;
+
     static after(n: any, func: any, ...args: any[]): any;
+
     static ary(func: any, n: any, guard: any): any;
+
     static assign(object: any, sources: any): any;
+
     static assignIn(object: any, sources: any): any;
+
     static assignInWith(object: any, sources: any): any;
+
     static assignWith(object: any, sources: any): any;
+
     static at(object: any, paths: any): any;
+
     static attempt(func: any, args: any): any;
+
     static before(n: any, func: any, ...args: any[]): any;
+
     static bind(func: any, thisArg: any, partials: any): any;
+
     static bindAll(object: any, methodNames: any): any;
+
     static bindKey(object: any, key: any, partials: any): any;
+
     static camelCase(string: any): any;
+
     static capitalize(string: any): any;
+
     static castArray(...args: any[]): any;
+
     static ceil(number: any, precision: any): any;
+
     static chain(value: any): any;
+
     static chunk(array: any, size: any, guard: any): any;
+
     static clamp(number: any, lower: any, upper: any): any;
+
     static clone(value: any): any;
+
     static cloneDeep(value: any): any;
+
     static cloneDeepWith(value: any, customizer: any): any;
+
     static cloneWith(value: any, customizer: any): any;
+
     static compact(array: any): any;
+
     static concat(...args: any[]): any;
+
     static cond(pairs: any): any;
+
     static conforms(source: any): any;
+
     static conformsTo(object: any, source: any): any;
+
     static constant(value: any): any;
+
     static countBy(collection: any, iteratee: any): any;
+
     static create(prototype: any, properties: any): any;
+
     static curry(func: any, arity: any, guard: any): any;
+
     static curryRight(func: any, arity: any, guard: any): any;
+
     static debounce(func: any, wait: any, options: any, ...args: any[]): any;
+
     static deburr(string: any): any;
+
     static defaultTo(value: any, defaultValue: any): any;
-    static defaults(args: any): any;
+
+    static defaults(object: any, sources: any): any;
+
     static defaultsDeep(args: any): any;
+
     static defer(func: any, args: any): any;
+
     static delay(func: any, wait: any, args: any): any;
+
     static difference(array: any, values: any): any;
+
     static differenceBy(array: any, values: any): any;
+
     static differenceWith(array: any, values: any): any;
+
     static divide(value: any, other: any): any;
+
     static drop(array: any, n: any, guard: any): any;
+
     static dropRight(array: any, n: any, guard: any): any;
+
     static dropRightWhile(array: any, predicate: any): any;
+
     static dropWhile(array: any, predicate: any): any;
+
     static each(collection: any, iteratee: any): any;
+
     static eachRight(collection: any, iteratee: any): any;
+
     static endsWith(string: any, target: any, position: any): any;
+
     static entries(object: any): any;
+
     static entriesIn(object: any): any;
+
     static eq(value: any, other: any): any;
+
     static escape(string: any): any;
+
     static escapeRegExp(string: any): any;
+
     static every(collection: any, predicate: any, guard: any): any;
+
     static extend(object: any, sources: any): any;
+
     static extendWith(object: any, sources: any): any;
+
     static fill(array: any, value: any, start: any, end: any): any;
+
     static filter(collection: any, predicate: any): any;
+
     static find(collection: any, predicate: any, fromIndex: any): any;
+
     static findIndex(array: any, predicate: any, fromIndex: any): any;
+
     static findKey(object: any, predicate: any): any;
+
     static findLast(collection: any, predicate: any, fromIndex: any): any;
+
     static findLastIndex(array: any, predicate: any, fromIndex: any): any;
+
     static findLastKey(object: any, predicate: any): any;
+
     static first(array: any): any;
+
     static flatMap(collection: any, iteratee: any): any;
+
     static flatMapDeep(collection: any, iteratee: any): any;
+
     static flatMapDepth(collection: any, iteratee: any, depth: any): any;
+
     static flatten(array: any): any;
+
     static flattenDeep(array: any): any;
+
     static flattenDepth(array: any, depth: any): any;
+
     static flip(func: any): any;
+
     static floor(number: any, precision: any): any;
+
     static flow(funcs: any, ...args: any[]): any;
+
     static flowRight(funcs: any, ...args: any[]): any;
+
     static forEach(collection: any, iteratee: any): any;
+
     static forEachRight(collection: any, iteratee: any): any;
+
     static forIn(object: any, iteratee: any): any;
+
     static forInRight(object: any, iteratee: any): any;
+
     static forOwn(object: any, iteratee: any): any;
+
     static forOwnRight(object: any, iteratee: any): any;
+
     static fromPairs(pairs: any): any;
+
     static functions(object: any): any;
+
     static functionsIn(object: any): any;
+
     static get(object: any, path: any, defaultValue: any): any;
+
     static groupBy(collection: any, iteratee: any): any;
+
     static gt(value: any, other: any): any;
+
     static gte(value: any, other: any): any;
+
     static has(object: any, path: any): any;
+
     static hasIn(object: any, path: any): any;
+
     static head(array: any): any;
+
     static identity(value: any): any;
+
     static inRange(number: any, start: any, end: any): any;
+
     static includes(collection: any, value: any, fromIndex: any, guard: any): any;
+
     static indexOf(array: any, value: any, fromIndex: any): any;
+
     static initial(array: any): any;
+
     static intersection(arrays: any): any;
+
     static intersectionBy(arrays: any): any;
+
     static intersectionWith(arrays: any): any;
+
     static invert(object: any, iteratee: any): any;
+
     static invertBy(object: any, iteratee: any): any;
+
     static invoke(object: any, path: any, args: any): any;
+
     static invokeMap(collection: any, path: any, args: any): any;
+
     static isArguments(value: any): any;
+
     static isArray(p0: any): any;
+
     static isArrayBuffer(value: any): any;
+
     static isArrayLike(value: any): any;
+
     static isArrayLikeObject(value: any): any;
+
     static isBoolean(value: any): any;
+
     static isBuffer(b: any): any;
+
     static isDate(value: any): any;
+
     static isElement(value: any): any;
+
     static isEmpty(value: any): any;
+
     static isEqual(value: any, other: any): any;
+
     static isEqualWith(value: any, other: any, customizer: any): any;
+
     static isError(value: any): any;
+
     static isFinite(value: any): any;
+
     static isFunction(value: any): any;
+
     static isInteger(value: any): any;
+
     static isLength(value: any): any;
+
     static isMap(value: any): any;
+
     static isMatch(object: any, source: any): any;
+
     static isMatchWith(object: any, source: any, customizer: any): any;
+
     static isNaN(value: any): any;
+
     static isNative(value: any): any;
+
     static isNil(value: any): any;
+
     static isNull(value: any): any;
+
     static isNumber(value: any): any;
+
     static isObject(value: any): any;
+
     static isObjectLike(value: any): any;
+
     static isPlainObject(value: any): any;
+
     static isRegExp(value: any): any;
+
     static isSafeInteger(value: any): any;
+
     static isSet(value: any): any;
+
     static isString(value: any): any;
+
     static isSymbol(value: any): any;
+
     static isTypedArray(value: any): any;
+
     static isUndefined(value: any): any;
+
     static isWeakMap(value: any): any;
+
     static isWeakSet(value: any): any;
+
     static iteratee(func: any): any;
+
     static join(array: any, separator: any): any;
+
     static kebabCase(string: any): any;
+
     static keyBy(collection: any, iteratee: any): any;
+
     static keys(object: any): any;
+
     static keysIn(object: any): any;
+
     static last(array: any): any;
+
     static lastIndexOf(array: any, value: any, fromIndex: any): any;
+
     static lowerCase(string: any): any;
+
     static lowerFirst(string: any): any;
+
     static lt(value: any, other: any): any;
+
     static lte(value: any, other: any): any;
+
     static map(collection: any, iteratee: any): any;
+
     static mapKeys(object: any, iteratee: any): any;
+
     static mapValues(object: any, iteratee: any): any;
+
     static matches(source: any): any;
+
     static matchesProperty(path: any, srcValue: any): any;
+
     static max(array: any): any;
+
     static maxBy(array: any, iteratee: any): any;
+
     static mean(array: any): any;
+
     static meanBy(array: any, iteratee: any): any;
+
     static memoize(func: any, resolver: any, ...args: any[]): any;
+
     static merge(object: any, sources: any): any;
+
     static mergeWith(object: any, sources: any): any;
+
     static method(path: any, args: any): any;
+
     static methodOf(object: any, args: any): any;
+
     static min(array: any): any;
+
     static minBy(array: any, iteratee: any): any;
+
     static mixin(object: any, source: any, options: any, ...args: any[]): any;
+
     static multiply(value: any, other: any): any;
+
     static negate(predicate: any, ...args: any[]): any;
+
     static noConflict(): any;
+
     static noop(): void;
+
     static now(): any;
+
     static nth(array: any, n: any): any;
+
     static nthArg(n: any): any;
+
     static omit(object: any, paths: any): any;
+
     static omitBy(object: any, predicate: any): any;
+
     static once(func: any): any;
+
     static orderBy(collection: any, iteratees: any, orders: any, guard: any): any;
+
     static over(iteratees: any): any;
+
     static overArgs(func: any, transforms: any): any;
+
     static overEvery(iteratees: any): any;
+
     static overSome(iteratees: any): any;
+
     static pad(string: any, length: any, chars: any): any;
+
     static padEnd(string: any, length: any, chars: any): any;
+
     static padStart(string: any, length: any, chars: any): any;
+
     static parseInt(string: any, radix: any, guard: any): any;
+
     static partial(func: any, partials: any): any;
+
     static partialRight(func: any, partials: any): any;
+
     static partition(collection: any, iteratee: any): any;
+
     static pick(object: any, paths: any): any;
+
     static pickBy(object: any, predicate: any): any;
+
     static property(path: any): any;
+
     static propertyOf(object: any): any;
+
     static pull(array: any, values: any): any;
+
     static pullAll(array: any, values: any): any;
+
     static pullAllBy(array: any, values: any, iteratee: any): any;
+
     static pullAllWith(array: any, values: any, comparator: any): any;
+
     static pullAt(array: any, indexes: any): any;
+
     static random(lower: any, upper: any, floating: any): any;
+
     static range(start: any, end: any, step: any): any;
+
     static rangeRight(start: any, end: any, step: any): any;
+
     static rearg(func: any, indexes: any): any;
+
     static reduce(collection: any, iteratee: any, accumulator: any, ...args: any[]): any;
+
     static reduceRight(collection: any, iteratee: any, accumulator: any, ...args: any[]): any;
+
     static reject(collection: any, predicate: any): any;
+
     static remove(array: any, predicate: any): any;
+
     static repeat(string: any, n: any, guard: any): any;
+
     static replace(...args: any[]): any;
+
     static rest(func: any, start: any): any;
+
     static result(object: any, path: any, defaultValue: any): any;
+
     static reverse(array: any): any;
+
     static round(number: any, precision: any): any;
+
     static runInContext(context: any, ...args: any[]): any;
+
     static sample(collection: any): any;
+
     static sampleSize(collection: any, n: any, guard: any): any;
+
     static set(object: any, path: any, value: any): any;
+
     static setWith(object: any, path: any, value: any, customizer: any): any;
+
     static shuffle(collection: any): any;
+
     static size(collection: any): any;
+
     static slice(array: any, start: any, end: any): any;
+
     static snakeCase(string: any): any;
+
     static some(collection: any, predicate: any, guard: any): any;
+
     static sortBy(collection: any, iteratees: any): any;
+
     static sortedIndex(array: any, value: any): any;
+
     static sortedIndexBy(array: any, value: any, iteratee: any): any;
+
     static sortedIndexOf(array: any, value: any): any;
+
     static sortedLastIndex(array: any, value: any): any;
+
     static sortedLastIndexBy(array: any, value: any, iteratee: any): any;
+
     static sortedLastIndexOf(array: any, value: any): any;
+
     static sortedUniq(array: any): any;
+
     static sortedUniqBy(array: any, iteratee: any): any;
+
     static split(string: any, separator: any, limit: any): any;
+
     static spread(func: any, start: any): any;
+
     static startCase(string: any): any;
+
     static startsWith(string: any, target: any, position: any): any;
+
     static stubArray(): any;
+
     static stubFalse(): any;
+
     static stubObject(): any;
+
     static stubString(): any;
+
     static stubTrue(): any;
+
     static subtract(value: any, other: any): any;
+
     static sum(array: any): any;
+
     static sumBy(array: any, iteratee: any): any;
+
     static tail(array: any): any;
+
     static take(array: any, n: any, guard: any): any;
+
     static takeRight(array: any, n: any, guard: any): any;
+
     static takeRightWhile(array: any, predicate: any): any;
+
     static takeWhile(array: any, predicate: any): any;
+
     static tap(value: any, interceptor: any): any;
+
     static template(string: any, options: any, guard: any): any;
+
     static templateSettings: {
         escape: RegExp;
         evaluate: RegExp;
@@ -583,231 +1159,399 @@ declare class lodash {
         interpolate: RegExp;
         variable: string;
     };
+
     static throttle(func: any, wait: any, options: any): any;
+
     static thru(value: any, interceptor: any): any;
+
     static times(n: any, iteratee: any): any;
+
     static toArray(value: any): any;
+
     static toFinite(value: any): any;
+
     static toInteger(value: any): any;
+
     static toLength(value: any): any;
+
     static toLower(value: any): any;
+
     static toNumber(value: any): any;
+
     static toPairs(object: any): any;
+
     static toPairsIn(object: any): any;
+
     static toPath(value: any): any;
+
     static toPlainObject(value: any): any;
+
     static toSafeInteger(value: any): any;
+
     static toString(value: any): any;
+
     static toUpper(value: any): any;
+
     static transform(object: any, iteratee: any, accumulator: any): any;
+
     static trim(string: any, chars: any, guard: any): any;
+
     static trimEnd(string: any, chars: any, guard: any): any;
+
     static trimStart(string: any, chars: any, guard: any): any;
+
     static truncate(string: any, options: any): any;
+
     static unary(func: any): any;
+
     static unescape(string: any): any;
+
     static union(arrays: any): any;
+
     static unionBy(arrays: any): any;
+
     static unionWith(arrays: any): any;
+
     static uniq(array: any): any;
+
     static uniqBy(array: any, iteratee: any): any;
+
     static uniqWith(array: any, comparator: any): any;
+
     static uniqueId(prefix: any): any;
+
     static unset(object: any, path: any): any;
+
     static unzip(array: any): any;
+
     static unzipWith(array: any, iteratee: any): any;
+
     static update(object: any, path: any, updater: any): any;
+
     static updateWith(object: any, path: any, updater: any, customizer: any): any;
+
     static upperCase(string: any): any;
+
     static upperFirst(string: any): any;
+
     static values(object: any): any;
+
     static valuesIn(object: any): any;
+
     static without(array: any, values: any): any;
+
     static words(string: any, pattern: any, guard: any): any;
+
     static wrap(value: any, wrapper: any): any;
+
     static xor(arrays: any): any;
+
     static xorBy(arrays: any): any;
+
     static xorWith(arrays: any): any;
+
     static zip(array: any): any;
+
     static zipObject(props: any, values: any): any;
+
     static zipObjectDeep(props: any, values: any): any;
+
     static zipWith(arrays: any): any;
+
 }
+
 declare namespace lodash {
     namespace assign {
         function toString(): any;
+
     }
+
     namespace assignIn {
         function toString(): any;
+
     }
+
     namespace assignInWith {
         function toString(): any;
+
     }
+
     namespace assignWith {
         function toString(): any;
+
     }
+
     namespace at {
         function toString(): any;
+
     }
+
     namespace attempt {
         function toString(): any;
+
     }
+
     namespace bind {
         // Circular reference from lodash.bind
         const placeholder: any;
+
         function toString(): any;
+
     }
+
     namespace bindAll {
         function toString(): any;
+
     }
+
     namespace bindKey {
         // Circular reference from lodash.bindKey
         const placeholder: any;
+
         function toString(): any;
+
     }
+
     namespace curry {
         // Circular reference from lodash.curry
         const placeholder: any;
+
     }
+
     namespace curryRight {
         // Circular reference from lodash.curryRight
         const placeholder: any;
+
     }
+
     namespace defaults {
         function toString(): any;
+
     }
+
     namespace defaultsDeep {
         function toString(): any;
+
     }
+
     namespace defer {
         function toString(): any;
+
     }
+
     namespace delay {
         function toString(): any;
+
     }
+
     namespace difference {
         function toString(): any;
+
     }
+
     namespace differenceBy {
         function toString(): any;
+
     }
+
     namespace differenceWith {
         function toString(): any;
+
     }
+
     namespace extend {
         function toString(): any;
+
     }
+
     namespace extendWith {
         function toString(): any;
+
     }
+
     namespace flow {
         function toString(): any;
+
     }
+
     namespace flowRight {
         function toString(): any;
+
     }
+
     namespace intersection {
         function toString(): any;
+
     }
+
     namespace intersectionBy {
         function toString(): any;
+
     }
+
     namespace intersectionWith {
         function toString(): any;
+
     }
+
     namespace invoke {
         function toString(): any;
+
     }
+
     namespace invokeMap {
         function toString(): any;
+
     }
+
     namespace memoize {
         class Cache {
             constructor(entries: any);
+
             clear(): void;
+
             delete(key: any): any;
+
             get(key: any): any;
+
             has(key: any): any;
+
             set(key: any, value: any): any;
+
         }
+
     }
+
     namespace merge {
         function toString(): any;
+
     }
+
     namespace mergeWith {
         function toString(): any;
+
     }
+
     namespace method {
         function toString(): any;
+
     }
+
     namespace methodOf {
         function toString(): any;
+
     }
+
     namespace omit {
         function toString(): any;
+
     }
+
     namespace over {
         function toString(): any;
+
     }
+
     namespace overArgs {
         function toString(): any;
+
     }
+
     namespace overEvery {
         function toString(): any;
+
     }
+
     namespace overSome {
         function toString(): any;
+
     }
+
     namespace partial {
         // Circular reference from lodash.partial
         const placeholder: any;
+
         function toString(): any;
+
     }
+
     namespace partialRight {
         // Circular reference from lodash.partialRight
         const placeholder: any;
+
         function toString(): any;
+
     }
+
     namespace pick {
         function toString(): any;
+
     }
+
     namespace pull {
         function toString(): any;
+
     }
+
     namespace pullAt {
         function toString(): any;
+
     }
+
     namespace rearg {
         function toString(): any;
+
     }
+
     namespace sortBy {
         function toString(): any;
+
     }
+
     namespace union {
         function toString(): any;
+
     }
+
     namespace unionBy {
         function toString(): any;
+
     }
+
     namespace unionWith {
         function toString(): any;
+
     }
+
     namespace without {
         function toString(): any;
+
     }
+
     namespace xor {
         function toString(): any;
+
     }
+
     namespace xorBy {
         function toString(): any;
+
     }
+
     namespace xorWith {
         function toString(): any;
+
     }
+
     namespace zip {
         function toString(): any;
+
     }
+
     namespace zipWith {
         function toString(): any;
+
     }
+
 }
+

--- a/baselines/module-path.d.ts
+++ b/baselines/module-path.d.ts
@@ -1,688 +1,1200 @@
 export const delimiter: string;
+
 export const sep: string;
-export function basename(path: any, ext: any): any;
-export function dirname(path: any): any;
-export function extname(path: any): any;
-export function format(pathObject: any): any;
-export function isAbsolute(path: any): any;
-export function join(...args: any[]): any;
-export function normalize(path: any): any;
-export function parse(path: any): any;
-export function relative(from: any, to: any): any;
-export function resolve(...args: any[]): any;
+
+export function basename(...args: any[]): void;
+
+export function dirname(...args: any[]): void;
+
+export function extname(...args: any[]): void;
+
+export function format(p0: any): any;
+
+export function isAbsolute(...args: any[]): void;
+
+export function join(...args: any[]): void;
+
+export function normalize(...args: any[]): void;
+
+export function parse(...args: any[]): void;
+
+export function relative(...args: any[]): void;
+
+export function resolve(...args: any[]): void;
+
+export function toNamespacedPath(...args: any[]): void;
+
 export namespace posix {
     const delimiter: string;
+
     const sep: string;
-    function basename(path: any, ext: any): any;
-    function dirname(path: any): any;
-    function extname(path: any): any;
-    function format(pathObject: any): any;
-    function isAbsolute(path: any): any;
-    function join(...args: any[]): any;
-    function normalize(path: any): any;
-    function parse(path: any): any;
-    function relative(from: any, to: any): any;
-    function resolve(...args: any[]): any;
+
+    function basename(...args: any[]): void;
+
+    function dirname(...args: any[]): void;
+
+    function extname(...args: any[]): void;
+
+    function format(p0: any): any;
+
+    function isAbsolute(...args: any[]): void;
+
+    function join(...args: any[]): void;
+
+    function normalize(...args: any[]): void;
+
+    function parse(...args: any[]): void;
+
+    function relative(...args: any[]): void;
+
+    function resolve(...args: any[]): void;
+
+    function toNamespacedPath(...args: any[]): void;
+
     namespace posix {
         const delimiter: string;
+
         const sep: string;
-        function basename(path: any, ext: any): any;
-        function dirname(path: any): any;
-        function extname(path: any): any;
-        function format(pathObject: any): any;
-        function isAbsolute(path: any): any;
-        function join(...args: any[]): any;
-        function normalize(path: any): any;
-        function parse(path: any): any;
-        function relative(from: any, to: any): any;
-        function resolve(...args: any[]): any;
+
+        function basename(...args: any[]): void;
+
+        function dirname(...args: any[]): void;
+
+        function extname(...args: any[]): void;
+
+        function format(p0: any): any;
+
+        function isAbsolute(...args: any[]): void;
+
+        function join(...args: any[]): void;
+
+        function normalize(...args: any[]): void;
+
+        function parse(...args: any[]): void;
+
+        function relative(...args: any[]): void;
+
+        function resolve(...args: any[]): void;
+
+        function toNamespacedPath(...args: any[]): void;
+
         namespace posix {
             const delimiter: string;
+
             const sep: string;
-            function basename(path: any, ext: any): any;
-            function dirname(path: any): any;
-            function extname(path: any): any;
-            function format(pathObject: any): any;
-            function isAbsolute(path: any): any;
-            function join(...args: any[]): any;
-            function normalize(path: any): any;
-            function parse(path: any): any;
-            function relative(from: any, to: any): any;
-            function resolve(...args: any[]): any;
+
+            function basename(...args: any[]): void;
+
+            function dirname(...args: any[]): void;
+
+            function extname(...args: any[]): void;
+
+            function format(p0: any): any;
+
+            function isAbsolute(...args: any[]): void;
+
+            function join(...args: any[]): void;
+
+            function normalize(...args: any[]): void;
+
+            function parse(...args: any[]): void;
+
+            function relative(...args: any[]): void;
+
+            function resolve(...args: any[]): void;
+
+            function toNamespacedPath(...args: any[]): void;
+
             namespace posix {
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const basename: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const extname: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const format: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const join: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const parse: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const posix: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const relative: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const sep: any;
+
+                // Too-deep object hierarchy from path.posix.posix.posix.posix
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.posix
                 const win32: any;
+
             }
+
             namespace win32 {
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const basename: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const extname: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const format: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const join: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const parse: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const posix: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const relative: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const sep: any;
+
+                // Too-deep object hierarchy from path.posix.posix.posix.win32
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.posix.posix.posix.win32
                 const win32: any;
+
             }
+
         }
+
         namespace win32 {
             const delimiter: string;
+
             const sep: string;
-            function basename(path: any, ext: any): any;
-            function dirname(path: any): any;
-            function extname(path: any): any;
-            function format(pathObject: any): any;
-            function isAbsolute(path: any): any;
-            function join(...args: any[]): any;
-            function normalize(path: any): any;
-            function parse(path: any): any;
-            function relative(from: any, to: any): any;
-            function resolve(...args: any[]): any;
+
+            function basename(...args: any[]): void;
+
+            function dirname(...args: any[]): void;
+
+            function extname(...args: any[]): void;
+
+            function format(p0: any): any;
+
+            function isAbsolute(...args: any[]): void;
+
+            function join(...args: any[]): void;
+
+            function normalize(...args: any[]): void;
+
+            function parse(...args: any[]): void;
+
+            function relative(...args: any[]): void;
+
+            function resolve(...args: any[]): void;
+
+            function toNamespacedPath(...args: any[]): void;
+
             namespace posix {
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const basename: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const extname: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const format: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const join: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const parse: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const posix: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const relative: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const sep: any;
+
+                // Too-deep object hierarchy from path.posix.posix.win32.posix
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.posix
                 const win32: any;
+
             }
+
             namespace win32 {
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const basename: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const extname: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const format: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const join: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const parse: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const posix: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const relative: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const sep: any;
+
+                // Too-deep object hierarchy from path.posix.posix.win32.win32
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.posix.posix.win32.win32
                 const win32: any;
+
             }
+
         }
+
     }
+
     namespace win32 {
         const delimiter: string;
+
         const sep: string;
-        function basename(path: any, ext: any): any;
-        function dirname(path: any): any;
-        function extname(path: any): any;
-        function format(pathObject: any): any;
-        function isAbsolute(path: any): any;
-        function join(...args: any[]): any;
-        function normalize(path: any): any;
-        function parse(path: any): any;
-        function relative(from: any, to: any): any;
-        function resolve(...args: any[]): any;
+
+        function basename(...args: any[]): void;
+
+        function dirname(...args: any[]): void;
+
+        function extname(...args: any[]): void;
+
+        function format(p0: any): any;
+
+        function isAbsolute(...args: any[]): void;
+
+        function join(...args: any[]): void;
+
+        function normalize(...args: any[]): void;
+
+        function parse(...args: any[]): void;
+
+        function relative(...args: any[]): void;
+
+        function resolve(...args: any[]): void;
+
+        function toNamespacedPath(...args: any[]): void;
+
         namespace posix {
             const delimiter: string;
+
             const sep: string;
-            function basename(path: any, ext: any): any;
-            function dirname(path: any): any;
-            function extname(path: any): any;
-            function format(pathObject: any): any;
-            function isAbsolute(path: any): any;
-            function join(...args: any[]): any;
-            function normalize(path: any): any;
-            function parse(path: any): any;
-            function relative(from: any, to: any): any;
-            function resolve(...args: any[]): any;
+
+            function basename(...args: any[]): void;
+
+            function dirname(...args: any[]): void;
+
+            function extname(...args: any[]): void;
+
+            function format(p0: any): any;
+
+            function isAbsolute(...args: any[]): void;
+
+            function join(...args: any[]): void;
+
+            function normalize(...args: any[]): void;
+
+            function parse(...args: any[]): void;
+
+            function relative(...args: any[]): void;
+
+            function resolve(...args: any[]): void;
+
+            function toNamespacedPath(...args: any[]): void;
+
             namespace posix {
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const basename: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const extname: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const format: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const join: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const parse: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const posix: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const relative: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const sep: any;
+
+                // Too-deep object hierarchy from path.posix.win32.posix.posix
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.posix
                 const win32: any;
+
             }
+
             namespace win32 {
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const basename: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const extname: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const format: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const join: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const parse: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const posix: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const relative: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const sep: any;
+
+                // Too-deep object hierarchy from path.posix.win32.posix.win32
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.posix.win32.posix.win32
                 const win32: any;
+
             }
+
         }
+
         namespace win32 {
             const delimiter: string;
+
             const sep: string;
-            function basename(path: any, ext: any): any;
-            function dirname(path: any): any;
-            function extname(path: any): any;
-            function format(pathObject: any): any;
-            function isAbsolute(path: any): any;
-            function join(...args: any[]): any;
-            function normalize(path: any): any;
-            function parse(path: any): any;
-            function relative(from: any, to: any): any;
-            function resolve(...args: any[]): any;
+
+            function basename(...args: any[]): void;
+
+            function dirname(...args: any[]): void;
+
+            function extname(...args: any[]): void;
+
+            function format(p0: any): any;
+
+            function isAbsolute(...args: any[]): void;
+
+            function join(...args: any[]): void;
+
+            function normalize(...args: any[]): void;
+
+            function parse(...args: any[]): void;
+
+            function relative(...args: any[]): void;
+
+            function resolve(...args: any[]): void;
+
+            function toNamespacedPath(...args: any[]): void;
+
             namespace posix {
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const basename: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const extname: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const format: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const join: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const parse: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const posix: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const relative: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const sep: any;
+
+                // Too-deep object hierarchy from path.posix.win32.win32.posix
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.posix
                 const win32: any;
+
             }
+
             namespace win32 {
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const basename: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const extname: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const format: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const join: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const parse: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const posix: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const relative: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const sep: any;
+
+                // Too-deep object hierarchy from path.posix.win32.win32.win32
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.posix.win32.win32.win32
                 const win32: any;
+
             }
+
         }
+
     }
+
 }
+
 export namespace win32 {
     const delimiter: string;
+
     const sep: string;
-    function basename(path: any, ext: any): any;
-    function dirname(path: any): any;
-    function extname(path: any): any;
-    function format(pathObject: any): any;
-    function isAbsolute(path: any): any;
-    function join(...args: any[]): any;
-    function normalize(path: any): any;
-    function parse(path: any): any;
-    function relative(from: any, to: any): any;
-    function resolve(...args: any[]): any;
+
+    function basename(...args: any[]): void;
+
+    function dirname(...args: any[]): void;
+
+    function extname(...args: any[]): void;
+
+    function format(p0: any): any;
+
+    function isAbsolute(...args: any[]): void;
+
+    function join(...args: any[]): void;
+
+    function normalize(...args: any[]): void;
+
+    function parse(...args: any[]): void;
+
+    function relative(...args: any[]): void;
+
+    function resolve(...args: any[]): void;
+
+    function toNamespacedPath(...args: any[]): void;
+
     namespace posix {
         const delimiter: string;
+
         const sep: string;
-        function basename(path: any, ext: any): any;
-        function dirname(path: any): any;
-        function extname(path: any): any;
-        function format(pathObject: any): any;
-        function isAbsolute(path: any): any;
-        function join(...args: any[]): any;
-        function normalize(path: any): any;
-        function parse(path: any): any;
-        function relative(from: any, to: any): any;
-        function resolve(...args: any[]): any;
+
+        function basename(...args: any[]): void;
+
+        function dirname(...args: any[]): void;
+
+        function extname(...args: any[]): void;
+
+        function format(p0: any): any;
+
+        function isAbsolute(...args: any[]): void;
+
+        function join(...args: any[]): void;
+
+        function normalize(...args: any[]): void;
+
+        function parse(...args: any[]): void;
+
+        function relative(...args: any[]): void;
+
+        function resolve(...args: any[]): void;
+
+        function toNamespacedPath(...args: any[]): void;
+
         namespace posix {
             const delimiter: string;
+
             const sep: string;
-            function basename(path: any, ext: any): any;
-            function dirname(path: any): any;
-            function extname(path: any): any;
-            function format(pathObject: any): any;
-            function isAbsolute(path: any): any;
-            function join(...args: any[]): any;
-            function normalize(path: any): any;
-            function parse(path: any): any;
-            function relative(from: any, to: any): any;
-            function resolve(...args: any[]): any;
+
+            function basename(...args: any[]): void;
+
+            function dirname(...args: any[]): void;
+
+            function extname(...args: any[]): void;
+
+            function format(p0: any): any;
+
+            function isAbsolute(...args: any[]): void;
+
+            function join(...args: any[]): void;
+
+            function normalize(...args: any[]): void;
+
+            function parse(...args: any[]): void;
+
+            function relative(...args: any[]): void;
+
+            function resolve(...args: any[]): void;
+
+            function toNamespacedPath(...args: any[]): void;
+
             namespace posix {
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const basename: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const extname: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const format: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const join: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const parse: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const posix: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const relative: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const sep: any;
+
+                // Too-deep object hierarchy from path.win32.posix.posix.posix
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.posix
                 const win32: any;
+
             }
+
             namespace win32 {
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const basename: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const extname: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const format: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const join: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const parse: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const posix: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const relative: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const sep: any;
+
+                // Too-deep object hierarchy from path.win32.posix.posix.win32
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.win32.posix.posix.win32
                 const win32: any;
+
             }
+
         }
+
         namespace win32 {
             const delimiter: string;
+
             const sep: string;
-            function basename(path: any, ext: any): any;
-            function dirname(path: any): any;
-            function extname(path: any): any;
-            function format(pathObject: any): any;
-            function isAbsolute(path: any): any;
-            function join(...args: any[]): any;
-            function normalize(path: any): any;
-            function parse(path: any): any;
-            function relative(from: any, to: any): any;
-            function resolve(...args: any[]): any;
+
+            function basename(...args: any[]): void;
+
+            function dirname(...args: any[]): void;
+
+            function extname(...args: any[]): void;
+
+            function format(p0: any): any;
+
+            function isAbsolute(...args: any[]): void;
+
+            function join(...args: any[]): void;
+
+            function normalize(...args: any[]): void;
+
+            function parse(...args: any[]): void;
+
+            function relative(...args: any[]): void;
+
+            function resolve(...args: any[]): void;
+
+            function toNamespacedPath(...args: any[]): void;
+
             namespace posix {
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const basename: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const extname: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const format: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const join: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const parse: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const posix: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const relative: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const sep: any;
+
+                // Too-deep object hierarchy from path.win32.posix.win32.posix
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.posix
                 const win32: any;
+
             }
+
             namespace win32 {
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const basename: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const extname: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const format: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const join: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const parse: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const posix: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const relative: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const sep: any;
+
+                // Too-deep object hierarchy from path.win32.posix.win32.win32
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.win32.posix.win32.win32
                 const win32: any;
+
             }
+
         }
+
     }
+
     namespace win32 {
         const delimiter: string;
+
         const sep: string;
-        function basename(path: any, ext: any): any;
-        function dirname(path: any): any;
-        function extname(path: any): any;
-        function format(pathObject: any): any;
-        function isAbsolute(path: any): any;
-        function join(...args: any[]): any;
-        function normalize(path: any): any;
-        function parse(path: any): any;
-        function relative(from: any, to: any): any;
-        function resolve(...args: any[]): any;
+
+        function basename(...args: any[]): void;
+
+        function dirname(...args: any[]): void;
+
+        function extname(...args: any[]): void;
+
+        function format(p0: any): any;
+
+        function isAbsolute(...args: any[]): void;
+
+        function join(...args: any[]): void;
+
+        function normalize(...args: any[]): void;
+
+        function parse(...args: any[]): void;
+
+        function relative(...args: any[]): void;
+
+        function resolve(...args: any[]): void;
+
+        function toNamespacedPath(...args: any[]): void;
+
         namespace posix {
             const delimiter: string;
+
             const sep: string;
-            function basename(path: any, ext: any): any;
-            function dirname(path: any): any;
-            function extname(path: any): any;
-            function format(pathObject: any): any;
-            function isAbsolute(path: any): any;
-            function join(...args: any[]): any;
-            function normalize(path: any): any;
-            function parse(path: any): any;
-            function relative(from: any, to: any): any;
-            function resolve(...args: any[]): any;
+
+            function basename(...args: any[]): void;
+
+            function dirname(...args: any[]): void;
+
+            function extname(...args: any[]): void;
+
+            function format(p0: any): any;
+
+            function isAbsolute(...args: any[]): void;
+
+            function join(...args: any[]): void;
+
+            function normalize(...args: any[]): void;
+
+            function parse(...args: any[]): void;
+
+            function relative(...args: any[]): void;
+
+            function resolve(...args: any[]): void;
+
+            function toNamespacedPath(...args: any[]): void;
+
             namespace posix {
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const basename: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const extname: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const format: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const join: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const parse: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const posix: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const relative: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const sep: any;
+
+                // Too-deep object hierarchy from path.win32.win32.posix.posix
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.posix
                 const win32: any;
+
             }
+
             namespace win32 {
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const basename: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const extname: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const format: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const join: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const parse: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const posix: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const relative: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const sep: any;
+
+                // Too-deep object hierarchy from path.win32.win32.posix.win32
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.win32.win32.posix.win32
                 const win32: any;
+
             }
+
         }
+
         namespace win32 {
             const delimiter: string;
+
             const sep: string;
-            function basename(path: any, ext: any): any;
-            function dirname(path: any): any;
-            function extname(path: any): any;
-            function format(pathObject: any): any;
-            function isAbsolute(path: any): any;
-            function join(...args: any[]): any;
-            function normalize(path: any): any;
-            function parse(path: any): any;
-            function relative(from: any, to: any): any;
-            function resolve(...args: any[]): any;
+
+            function basename(...args: any[]): void;
+
+            function dirname(...args: any[]): void;
+
+            function extname(...args: any[]): void;
+
+            function format(p0: any): any;
+
+            function isAbsolute(...args: any[]): void;
+
+            function join(...args: any[]): void;
+
+            function normalize(...args: any[]): void;
+
+            function parse(...args: any[]): void;
+
+            function relative(...args: any[]): void;
+
+            function resolve(...args: any[]): void;
+
+            function toNamespacedPath(...args: any[]): void;
+
             namespace posix {
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const basename: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const extname: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const format: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const join: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const parse: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const posix: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const relative: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const sep: any;
+
+                // Too-deep object hierarchy from path.win32.win32.win32.posix
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.posix
                 const win32: any;
+
             }
+
             namespace win32 {
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const basename: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const delimiter: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const dirname: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const extname: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const format: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const isAbsolute: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const join: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const normalize: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const parse: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const posix: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const relative: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const resolve: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const sep: any;
+
+                // Too-deep object hierarchy from path.win32.win32.win32.win32
+                const toNamespacedPath: any;
+
                 // Too-deep object hierarchy from path.win32.win32.win32.win32
                 const win32: any;
+
             }
+
         }
+
     }
+
 }
+

--- a/baselines/module-yargs.d.ts
+++ b/baselines/module-yargs.d.ts
@@ -1,69 +1,135 @@
 export = yargs;
+
 declare function yargs(processArgs: any, cwd: any): any;
+
 declare namespace yargs {
     const $0: string;
+
     const argv: {
         $0: string;
     };
+
     const parsed: boolean;
+
     function addHelpOpt(p0: any, p1: any): any;
+
     function alias(p0: any, p1: any): any;
+
     function array(p0: any): any;
+
     function check(p0: any): any;
+
     function choices(p0: any, p1: any): any;
+
     function command(p0: any, p1: any, p2: any, p3: any): any;
+
     function commandDir(p0: any, p1: any): any;
+
     function completion(p0: any, p1: any, p2: any): any;
+
     function config(p0: any, p1: any, p2: any): any;
+
     function count(p0: any): any;
+
     function defaults(p0: any, p1: any, p2: any): any;
+
     function demand(p0: any, p1: any, p2: any): any;
+
     function describe(p0: any, p1: any): any;
+
     function detectLocale(p0: any): any;
+
     function env(p0: any): any;
+
     function epilog(p0: any): any;
+
     function epilogue(p0: any): any;
+
     function example(p0: any, p1: any): any;
+
     function exitProcess(p0: any): any;
+
     function fail(p0: any): any;
+
     function getCommandInstance(): any;
+
     function getCompletion(p0: any, p1: any): any;
+
     function getContext(): any;
+
     function getDemanded(): any;
+
     function getDetectLocale(): any;
+
     function getExitProcess(): any;
+
     function getGroups(): any;
+
     function getOptions(): any;
+
     function getStrict(): any;
+
     function getUsageInstance(): any;
+
     function getValidationInstance(): any;
+
     function global(p0: any): any;
+
     function group(p0: any, p1: any): any;
+
     function help(p0: any, p1: any): any;
+
     function implies(p0: any, p1: any): any;
+
     function locale(p0: any): any;
+
     function nargs(p0: any, p1: any): any;
+
     function normalize(p0: any): any;
+
     function number(p0: any): any;
+
     function option(p0: any, p1: any): any;
+
     function options(p0: any, p1: any): any;
+
     function parse(p0: any, p1: any): any;
+
     function pkgConf(p0: any, p1: any): any;
+
     function require(p0: any, p1: any, p2: any): any;
+
     function required(p0: any, p1: any, p2: any): any;
+
     function requiresArg(p0: any): any;
+
     function reset(p0: any): any;
+
     function resetOptions(p0: any): any;
+
     function showCompletionScript(p0: any): any;
+
     function showHelp(p0: any): any;
+
     function showHelpOnFail(p0: any, p1: any): any;
+
     function skipValidation(p0: any): any;
+
     function strict(): any;
+
     function string(p0: any): any;
+
     function terminalWidth(): any;
+
     function updateLocale(p0: any): any;
+
     function updateStrings(p0: any): any;
+
     function usage(p0: any, p1: any): any;
+
     function version(p0: any, p1: any, p2: any): any;
+
     function wrap(p0: any): any;
+
 }
+

--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -6,138 +6,138 @@ import { join as joinPaths } from "path";
 import { format as formatUrl, parse as parseUrl } from 'url';
 
 export default function writeDefinitelyTypedPackage(
-		indexDtsContent: string, packageName: string, overwrite: boolean): void {
-	const packageDir = joinPaths("types", packageName);
+        indexDtsContent: string, packageName: string, overwrite: boolean): void {
+    const packageDir = joinPaths("types", packageName);
 
-	// Check for overwrite
-	if (!overwrite) {
-		if (existsSync(packageDir)) {
-			console.log(`Directory ${packageDir} already exists and -overwrite was not specified; exiting.`);
-			process.exit(2);
-		}
-	}
+    // Check for overwrite
+    if (!overwrite) {
+        if (existsSync(packageDir)) {
+            console.log(`Directory ${packageDir} already exists and -overwrite was not specified; exiting.`);
+            process.exit(2);
+        }
+    }
 
-	if (!existsSync(packageDir)) {
-		mkdirSync(packageDir);
-	}
+    if (!existsSync(packageDir)) {
+        mkdirSync(packageDir);
+    }
 
-	run(indexDtsContent, packageName, packageDir).catch(e => {
-		console.error(e);
-		process.exit(1);
-	});
+    run(indexDtsContent, packageName, packageDir).catch(e => {
+        console.error(e);
+        process.exit(1);
+    });
 }
 
 async function run(indexDtsContent: string, packageName: string, packageDir: string): Promise<void> {
-	const files: Array<[string, string]> = [
-		["index.d.ts", await getIndex(indexDtsContent, packageName)],
-		[`${packageName}-tests.ts`, ""],
-		["tsconfig.json", `${JSON.stringify(getTSConfig(packageName), undefined, 4)}\n`],
-		["tslint.json", '{ "extends": "dtslint/dt.json" }\n'],
-	];
+    const files: Array<[string, string]> = [
+        ["index.d.ts", await getIndex(indexDtsContent, packageName)],
+        [`${packageName}-tests.ts`, ""],
+        ["tsconfig.json", `${JSON.stringify(getTSConfig(packageName), undefined, 4)}\n`],
+        ["tslint.json", '{ "extends": "dtslint/dt.json" }\n'],
+    ];
 
-	for (const [name, text] of files) {
-		await writeFileSync(joinPaths(packageDir, name), text, "utf-8");
-	}
+    for (const [name, text] of files) {
+        await writeFileSync(joinPaths(packageDir, name), text, "utf-8");
+    }
 }
 
 async function getIndex(content: string, packageName: string): Promise<string> {
-	return `${await getHeader(packageName)}\n\n${content}`;
+    return `${await getHeader(packageName)}\n\n${content}`;
 }
 
 async function getHeader(packageName: string): Promise<string> {
-	let version = "x.x";
-	let project = "https://github.com/baz/foo " +
-		"(Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)";
-	try {
-		const reg: Registry = JSON.parse(await loadString(`http://registry.npmjs.org/${packageName}`));
-		const { latest } = reg["dist-tags"];
-		const { homepage } = reg.versions[latest];
+    let version = "x.x";
+    let project = "https://github.com/baz/foo " +
+        "(Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)";
+    try {
+        const reg: Registry = JSON.parse(await loadString(`http://registry.npmjs.org/${packageName}`));
+        const { latest } = reg["dist-tags"];
+        const { homepage } = reg.versions[latest];
 
-		version = latest.split(".").slice(0, 2).join("."); // Just major.minor
-		if (homepage !== undefined) project = homepage;
-	} catch (e) {
-		console.warn(`Warning: Could not retrieve version/homepage information: ${e.message}`);
-	}
+        version = latest.split(".").slice(0, 2).join("."); // Just major.minor
+        if (homepage !== undefined) project = homepage;
+    } catch (e) {
+        console.warn(`Warning: Could not retrieve version/homepage information: ${e.message}`);
+    }
 
-	let authorName = 'My Self';
-	try {
-		const globalGitConfig = parseGitConfig.sync({ cwd: homedir(), path: '.gitconfig' });
-		if (globalGitConfig.user && globalGitConfig.user.name) {
-			authorName = globalGitConfig.user.name;
-		}
-	} catch (e) {
-		console.warn(`Warning: Could not retrieve author name: ${e.message}`);
-	}
+    let authorName = 'My Self';
+    try {
+        const globalGitConfig = parseGitConfig.sync({ cwd: homedir(), path: '.gitconfig' });
+        if (globalGitConfig.user && globalGitConfig.user.name) {
+            authorName = globalGitConfig.user.name;
+        }
+    } catch (e) {
+        console.warn(`Warning: Could not retrieve author name: ${e.message}`);
+    }
 
-	let authorUserName = 'me';
-	try {
-		const repoGitConfig = parseGitConfig.sync({ path: joinPaths('.git', 'config') });
-		if (repoGitConfig['remote "origin"'] && repoGitConfig['remote "origin"'].url) {
-			const url = parseUrl(repoGitConfig['remote "origin"'].url);
-			if (url.hostname === 'github.com' && url.pathname) {
-				authorUserName = url.pathname.split('/')[1] || authorUserName;
-			}
-		}
-	} catch (e) {
-		console.warn(`Warning: Could not retrieve author's user name: ${e.message}`);
-	}
-	const authorUrl = formatUrl({
-		protocol: 'https',
-		hostname: 'github.com',
-		pathname: authorUserName,
-	});
+    let authorUserName = 'me';
+    try {
+        const repoGitConfig = parseGitConfig.sync({ path: joinPaths('.git', 'config') });
+        if (repoGitConfig['remote "origin"'] && repoGitConfig['remote "origin"'].url) {
+            const url = parseUrl(repoGitConfig['remote "origin"'].url);
+            if (url.hostname === 'github.com' && url.pathname) {
+                authorUserName = url.pathname.split('/')[1] || authorUserName;
+            }
+        }
+    } catch (e) {
+        console.warn(`Warning: Could not retrieve author's user name: ${e.message}`);
+    }
+    const authorUrl = formatUrl({
+        protocol: 'https',
+        hostname: 'github.com',
+        pathname: authorUserName,
+    });
 
-	return `// Type definitions for ${packageName} ${version}
+    return `// Type definitions for ${packageName} ${version}
 // Project: ${project}
 // Definitions by: ${authorName} <${authorUrl}>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`;
 }
 
 function getTSConfig(packageName: string): {} {
-	return {
-		compilerOptions: {
-			module: "commonjs",
-			lib: ["es6"],
-			noImplicitAny: true,
-			noImplicitThis: true,
-			strictFunctionTypes: true,
-			strictNullChecks: true,
-			baseUrl: "../",
-			typeRoots: ["../"],
-			types: [],
-			noEmit: true,
-			forceConsistentCasingInFileNames: true,
-		},
-		files: [
-			"index.d.ts",
-			`${packageName}-tests.ts`,
-		],
-	};
+    return {
+        compilerOptions: {
+            module: "commonjs",
+            lib: ["es6"],
+            noImplicitAny: true,
+            noImplicitThis: true,
+            strictFunctionTypes: true,
+            strictNullChecks: true,
+            baseUrl: "../",
+            typeRoots: ["../"],
+            types: [],
+            noEmit: true,
+            forceConsistentCasingInFileNames: true,
+        },
+        files: [
+            "index.d.ts",
+            `${packageName}-tests.ts`,
+        ],
+    };
 }
 
 interface Registry {
-	name: string;
-	description: string;
-	"dist-tags": { latest: string };
-	versions: { [version: string]: Package };
+    name: string;
+    description: string;
+    "dist-tags": { latest: string };
+    versions: { [version: string]: Package };
 }
 
 interface Package {
-	name: string;
-	description: string;
-	version: string;
-	homepage?: string;
+    name: string;
+    description: string;
+    version: string;
+    homepage?: string;
 }
 
 function loadString(url: string): Promise<string> {
-	return new Promise((resolve, reject) => {
-		get(url, res => {
-			if (res.statusCode !== 200) {
-				return reject(new Error(`HTTP Error ${res.statusCode}: ${STATUS_CODES[res.statusCode || 500]} for ${url}`));
-			}
-			let rawData = "";
-			res.on("data", (chunk: any) => rawData += chunk);
-			res.on("end", () => resolve(rawData));
-		}).on("error", (e: Error) => reject(e));
-	});
+    return new Promise((resolve, reject) => {
+        get(url, res => {
+            if (res.statusCode !== 200) {
+                return reject(new Error(`HTTP Error ${res.statusCode}: ${STATUS_CODES[res.statusCode || 500]} for ${url}`));
+            }
+            let rawData = "";
+            res.on("data", (chunk: any) => rawData += chunk);
+            res.on("end", () => resolve(rawData));
+        }).on("error", (e: Error) => reject(e));
+    });
 }

--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -47,7 +47,8 @@ async function getIndex(content: string, packageName: string): Promise<string> {
 async function getHeader(packageName: string): Promise<string> {
     let version = "x.x";
     let project = "https://github.com/baz/foo " +
-        "(Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)";
+        "(Does not have to be to GitHub, " +
+        "but prefer linking to a source code repository rather than to a project website.)";
     try {
         const reg: Registry = JSON.parse(await loadString(`http://registry.npmjs.org/${packageName}`));
         const { latest } = reg["dist-tags"];
@@ -133,7 +134,8 @@ function loadString(url: string): Promise<string> {
     return new Promise((resolve, reject) => {
         get(url, res => {
             if (res.statusCode !== 200) {
-                return reject(new Error(`HTTP Error ${res.statusCode}: ${STATUS_CODES[res.statusCode || 500]} for ${url}`));
+                return reject(
+                    new Error(`HTTP Error ${res.statusCode}: ${STATUS_CODES[res.statusCode || 500]} for ${url}`));
             }
             let rawData = "";
             res.on("data", (chunk: any) => rawData += chunk);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -172,7 +172,8 @@ function getTopLevelDeclarations(name: string, obj: any): dom.NamespaceMember[] 
                                 primaryDecl.members.push(create.property(p.name, p.type, dom.DeclarationFlags.Static));
                                 break;
                             case 'function':
-                                primaryDecl.members.push(create.method(p.name, p.parameters, p.returnType, dom.DeclarationFlags.Static));
+                                primaryDecl.members.push(
+                                    create.method(p.name, p.parameters, p.returnType, dom.DeclarationFlags.Static));
                                 break;
                             default:
                                 ns.members.push(p);
@@ -192,7 +193,8 @@ function getTopLevelDeclarations(name: string, obj: any): dom.NamespaceMember[] 
             if (typeof simpleType === 'string' || simpleType.kind === 'name' || simpleType.kind === 'array') {
                 const result = dom.create.const(name, simpleType);
                 if (simpleType === 'string') {
-                    result.comment = `Value of string: "${simpleType.substr(0, 100)}${simpleType.length > 100 ? '...' : ''}"`;
+                    const preview = `"${simpleType.substr(0, 100)}${simpleType.length > 100 ? '...' : ''}"`;
+                    result.comment = "Value of string: " + preview;
                 }
                 return [result];
             }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,383 +3,383 @@ import { create, reservedWords } from 'dts-dom';
 import * as ts from 'typescript';
 
 const enum ValueTypes {
-	None = 0,
-	Class = 1 << 0,
-	Function = 1 << 1,
-	Object = 1 << 2,
-	Primitive = 1 << 3,
-	NullOrUndefined = 1 << 4,
-	Unknown = 1 << 5,
+    None = 0,
+    Class = 1 << 0,
+    Function = 1 << 1,
+    Object = 1 << 2,
+    Primitive = 1 << 3,
+    NullOrUndefined = 1 << 4,
+    Unknown = 1 << 5,
 }
 
 const builtins: { [name: string]: (new (...args: any[]) => any) | undefined } = {
-	Date,
-	RegExp,
-	Map: (typeof Map !== 'undefined') ? Map : undefined,
-	HTMLElement: (typeof HTMLElement !== 'undefined') ? HTMLElement : undefined,
+    Date,
+    RegExp,
+    Map: (typeof Map !== 'undefined') ? Map : undefined,
+    HTMLElement: (typeof HTMLElement !== 'undefined') ? HTMLElement : undefined,
 };
 
 function forceAsIdentifier(s: string): string {
-	// TODO: Make this more comprehensive
-	let ret = s.replace(/-/g, '_');
-	if (ret.indexOf('@') === 0 && ret.indexOf('/') !== -1) {
-		// we have a scoped module, e.g. @bla/foo
-		// which should be converted to   bla__foo
-		ret = ret.substr(1).replace('/', '__');
-	}
-	return ret;
+    // TODO: Make this more comprehensive
+    let ret = s.replace(/-/g, '_');
+    if (ret.indexOf('@') === 0 && ret.indexOf('/') !== -1) {
+        // we have a scoped module, e.g. @bla/foo
+        // which should be converted to   bla__foo
+        ret = ret.substr(1).replace('/', '__');
+    }
+    return ret;
 }
 
 function getValueTypes(value: any): ValueTypes {
-	if (typeof value === 'object') {
-		// Objects can't be callable, so no need to check for class / function
-		return ValueTypes.Object;
-	} else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-		return ValueTypes.Primitive;
-	} else if (value === null || value === undefined) {
-		return ValueTypes.NullOrUndefined;
-	} else if (typeof value === 'function') {
-		if (isClasslike(value)) {
-			return ValueTypes.Class | (hasCloduleProperties(value) ? ValueTypes.Object : ValueTypes.None);
-		} else {
-			return ValueTypes.Function | (hasFunduleProperties(value) ? ValueTypes.Object : ValueTypes.None);
-		}
-	} else {
-		return ValueTypes.Unknown;
-	}
+    if (typeof value === 'object') {
+        // Objects can't be callable, so no need to check for class / function
+        return ValueTypes.Object;
+    } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return ValueTypes.Primitive;
+    } else if (value === null || value === undefined) {
+        return ValueTypes.NullOrUndefined;
+    } else if (typeof value === 'function') {
+        if (isClasslike(value)) {
+            return ValueTypes.Class | (hasCloduleProperties(value) ? ValueTypes.Object : ValueTypes.None);
+        } else {
+            return ValueTypes.Function | (hasFunduleProperties(value) ? ValueTypes.Object : ValueTypes.None);
+        }
+    } else {
+        return ValueTypes.Unknown;
+    }
 }
 
 // A class has clodule properties if it has any classes. Anything else can be written with 'static'
 function hasCloduleProperties(c: any): boolean {
-	return getKeysOfObject(c).some(k => isClasslike(c[k]));
+    return getKeysOfObject(c).some(k => isClasslike(c[k]));
 }
 
 // A function has fundule properties if it has any own properties not belonging to Function.prototype
 function hasFunduleProperties(fn: any): boolean {
-	return getKeysOfObject(fn).some(k => (<any> Function)[k] === undefined);
+    return getKeysOfObject(fn).some(k => (<any> Function)[k] === undefined);
 }
 
 export function generateModuleDeclarationFile(nameHint: string, root: any) {
-	const localName = forceAsIdentifier(nameHint);
-	const decls = getTopLevelDeclarations(localName, root);
-	// If we get back just a namespace, we can avoid writing an export=
-	if (decls.length === 1 && decls[0].kind === 'namespace') {
-		// Hoist out all the declarations and export them
-		const members = (decls[0] as dom.NamespaceDeclaration).members;
-		for (const m of members) m.flags = m.flags! | dom.DeclarationFlags.Export;
-		return members.map(m => dom.emit(m)).join('');
-	} else {
-		// Going to have to write an export=
-		const result: string[] = decls.map(d => dom.emit(d));
-		result.unshift(dom.emit(dom.create.exportEquals(localName)));
-		return result.join('');
-	}
+    const localName = forceAsIdentifier(nameHint);
+    const decls = getTopLevelDeclarations(localName, root);
+    // If we get back just a namespace, we can avoid writing an export=
+    if (decls.length === 1 && decls[0].kind === 'namespace') {
+        // Hoist out all the declarations and export them
+        const members = (decls[0] as dom.NamespaceDeclaration).members;
+        for (const m of members) m.flags = m.flags! | dom.DeclarationFlags.Export;
+        return members.map(m => dom.emit(m)).join('');
+    } else {
+        // Going to have to write an export=
+        const result: string[] = decls.map(d => dom.emit(d));
+        result.unshift(dom.emit(dom.create.exportEquals(localName)));
+        return result.join('');
+    }
 }
 
 export function generateIdentifierDeclarationFile(name: string, value: any): string {
-	const result = getTopLevelDeclarations(name, value);
-	return result.map(d => dom.emit(d)).join('\r\n');
+    const result = getTopLevelDeclarations(name, value);
+    return result.map(d => dom.emit(d)).join('\r\n');
 }
 
 const walkStack = new Set<any>();
 
 const reservedFunctionProperties = Object.getOwnPropertyNames(() => {});
 function getKeysOfObject(obj: object) {
-	let keys: string[] = [];
-	let chain: {} = obj;
-	do {
-		if (chain == null) break;
-		keys = keys.concat(Object.getOwnPropertyNames(chain));
-		chain = Object.getPrototypeOf(chain);
-	} while (chain !== Object.prototype && chain !== Function.prototype);
-	keys = Array.from(new Set(keys));
-	keys = keys.filter(s => isVisitableName(s));
-	if (typeof obj === 'function') {
-		keys = keys.filter(k => reservedFunctionProperties.indexOf(k) < 0);
-	}
+    let keys: string[] = [];
+    let chain: {} = obj;
+    do {
+        if (chain == null) break;
+        keys = keys.concat(Object.getOwnPropertyNames(chain));
+        chain = Object.getPrototypeOf(chain);
+    } while (chain !== Object.prototype && chain !== Function.prototype);
+    keys = Array.from(new Set(keys));
+    keys = keys.filter(s => isVisitableName(s));
+    if (typeof obj === 'function') {
+        keys = keys.filter(k => reservedFunctionProperties.indexOf(k) < 0);
+    }
 
-	keys.sort();
-	return keys;
+    keys.sort();
+    return keys;
 }
 
 function isVisitableName(s: string) {
-	return (s[0] !== '_') && (["caller", "arguments", "constructor", "super_", "prototype"].indexOf(s) < 0);
+    return (s[0] !== '_') && (["caller", "arguments", "constructor", "super_", "prototype"].indexOf(s) < 0);
 }
 
 function isLegalIdentifier(s: string) {
-	if (s.length === 0) {
-		return false;
-	}
-	if (!ts.isIdentifierStart(s.charCodeAt(0), ts.ScriptTarget.Latest)) {
-		return false;
-	}
-	for (let i = 1; i < s.length; i++) {
-		if (!ts.isIdentifierPart(s.charCodeAt(i), ts.ScriptTarget.Latest)) {
-			return false;
-		}
-	}
-	return reservedWords.indexOf(s) < 0;
+    if (s.length === 0) {
+        return false;
+    }
+    if (!ts.isIdentifierStart(s.charCodeAt(0), ts.ScriptTarget.Latest)) {
+        return false;
+    }
+    for (let i = 1; i < s.length; i++) {
+        if (!ts.isIdentifierPart(s.charCodeAt(i), ts.ScriptTarget.Latest)) {
+            return false;
+        }
+    }
+    return reservedWords.indexOf(s) < 0;
 }
 
 function isClasslike(obj: { prototype: any }): boolean {
-	return !!(obj.prototype && Object.getOwnPropertyNames(obj.prototype).length > 1);
+    return !!(obj.prototype && Object.getOwnPropertyNames(obj.prototype).length > 1);
 }
 
 const keyStack: string[] = [];
 function getTopLevelDeclarations(name: string, obj: any): dom.NamespaceMember[] {
-	if (walkStack.has(obj) || keyStack.length > 4) {
-		// Circular or too-deep reference
-		const result = create.const(name, dom.type.any);
-		result.comment = (walkStack.has(obj) ? 'Circular reference' : 'Too-deep object hierarchy') +
-			` from ${keyStack.join('.')}`;
-		return [result];
-	}
+    if (walkStack.has(obj) || keyStack.length > 4) {
+        // Circular or too-deep reference
+        const result = create.const(name, dom.type.any);
+        result.comment = (walkStack.has(obj) ? 'Circular reference' : 'Too-deep object hierarchy') +
+            ` from ${keyStack.join('.')}`;
+        return [result];
+    }
 
-	if (!isLegalIdentifier(name)) return [];
+    if (!isLegalIdentifier(name)) return [];
 
-	walkStack.add(obj);
-	keyStack.push(name);
-	const res = getResult();
-	keyStack.pop();
-	walkStack.delete(obj);
-	return res;
+    walkStack.add(obj);
+    keyStack.push(name);
+    const res = getResult();
+    keyStack.pop();
+    walkStack.delete(obj);
+    return res;
 
-	function getResult(): dom.NamespaceMember[] {
-		if (typeof obj === 'function') {
-			const funcType = getParameterListAndReturnType(obj, parseFunctionBody(obj));
-			const ns = dom.create.namespace(name);
-			let primaryDecl: dom.NamespaceMember;
-			if (isClasslike(obj)) {
-				const cls = dom.create.class(name);
-				getClassPrototypeMembers(obj).forEach(m => cls.members.push(m));
-				cls.members.push(dom.create.constructor(funcType[0]));
-				cls.members.sort(declarationComparer);
-				primaryDecl = cls;
-			} else {
-				const parsedFunction = parseFunctionBody(obj);
-				const info = getParameterListAndReturnType(obj, parsedFunction);
-				primaryDecl = dom.create.function(name, info[0], info[1]);
-			}
+    function getResult(): dom.NamespaceMember[] {
+        if (typeof obj === 'function') {
+            const funcType = getParameterListAndReturnType(obj, parseFunctionBody(obj));
+            const ns = dom.create.namespace(name);
+            let primaryDecl: dom.NamespaceMember;
+            if (isClasslike(obj)) {
+                const cls = dom.create.class(name);
+                getClassPrototypeMembers(obj).forEach(m => cls.members.push(m));
+                cls.members.push(dom.create.constructor(funcType[0]));
+                cls.members.sort(declarationComparer);
+                primaryDecl = cls;
+            } else {
+                const parsedFunction = parseFunctionBody(obj);
+                const info = getParameterListAndReturnType(obj, parsedFunction);
+                primaryDecl = dom.create.function(name, info[0], info[1]);
+            }
 
-			// Get clodule/fundule members
-			const keys = getKeysOfObject(obj);
-			for (const k of keys) {
-				getTopLevelDeclarations(k!, obj[k!]).forEach(p => {
-					if (primaryDecl.kind === "class") {
-						// Transform certain declarations into static members
-						switch (p.kind) {
-							case 'const':
-								primaryDecl.members.push(create.property(p.name, p.type, dom.DeclarationFlags.Static));
-								break;
-							case 'function':
-								primaryDecl.members.push(create.method(p.name, p.parameters, p.returnType, dom.DeclarationFlags.Static));
-								break;
-							default:
-								ns.members.push(p);
-								break;
-						}
-					} else {
-						ns.members.push(p);
-					}
-				});
-				ns.members.sort(declarationComparer);
-			}
+            // Get clodule/fundule members
+            const keys = getKeysOfObject(obj);
+            for (const k of keys) {
+                getTopLevelDeclarations(k!, obj[k!]).forEach(p => {
+                    if (primaryDecl.kind === "class") {
+                        // Transform certain declarations into static members
+                        switch (p.kind) {
+                            case 'const':
+                                primaryDecl.members.push(create.property(p.name, p.type, dom.DeclarationFlags.Static));
+                                break;
+                            case 'function':
+                                primaryDecl.members.push(create.method(p.name, p.parameters, p.returnType, dom.DeclarationFlags.Static));
+                                break;
+                            default:
+                                ns.members.push(p);
+                                break;
+                        }
+                    } else {
+                        ns.members.push(p);
+                    }
+                });
+                ns.members.sort(declarationComparer);
+            }
 
-			return ns.members.length > 0 ? [primaryDecl, ns] : [primaryDecl];
-		} else if (typeof obj === 'object') {
-			// If we can immediately resolve this to a simple declaration, just do so
-			const simpleType = getTypeOfValue(obj);
-			if (typeof simpleType === 'string' || simpleType.kind === 'name' || simpleType.kind === 'array') {
-				const result = dom.create.const(name, simpleType);
-				if (simpleType === 'string') {
-					result.comment = `Value of string: "${simpleType.substr(0, 100)}${simpleType.length > 100 ? '...' : ''}"`;
-				}
-				return [result];
-			}
+            return ns.members.length > 0 ? [primaryDecl, ns] : [primaryDecl];
+        } else if (typeof obj === 'object') {
+            // If we can immediately resolve this to a simple declaration, just do so
+            const simpleType = getTypeOfValue(obj);
+            if (typeof simpleType === 'string' || simpleType.kind === 'name' || simpleType.kind === 'array') {
+                const result = dom.create.const(name, simpleType);
+                if (simpleType === 'string') {
+                    result.comment = `Value of string: "${simpleType.substr(0, 100)}${simpleType.length > 100 ? '...' : ''}"`;
+                }
+                return [result];
+            }
 
-			// If anything in here is classlike or functionlike, write it as a namespace.
-			// Otherwise, write as a 'const'
-			const keys = getKeysOfObject(obj);
-			let constituentTypes = ValueTypes.None;
-			for (const k of keys) {
-				constituentTypes = constituentTypes | getValueTypes((<any> obj)[k!]);
-			}
-			if (constituentTypes & (ValueTypes.Class | ValueTypes.Function)) {
-				const ns = dom.create.namespace(name);
-				for (const k of keys) {
-					const decls = getTopLevelDeclarations(k!, (<any> obj)[k!]);
-					decls.forEach(d => ns.members.push(d));
-				}
-				ns.members.sort(declarationComparer);
-				return [ns];
-			} else {
-				return [dom.create.const(name, simpleType)];
-			}
-		} else if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean') {
-			return [create.const(name, <dom.Type> (typeof obj))];
-		} else {
-			return [create.const(name, dom.type.any)];
-		}
-	}
+            // If anything in here is classlike or functionlike, write it as a namespace.
+            // Otherwise, write as a 'const'
+            const keys = getKeysOfObject(obj);
+            let constituentTypes = ValueTypes.None;
+            for (const k of keys) {
+                constituentTypes = constituentTypes | getValueTypes((<any> obj)[k!]);
+            }
+            if (constituentTypes & (ValueTypes.Class | ValueTypes.Function)) {
+                const ns = dom.create.namespace(name);
+                for (const k of keys) {
+                    const decls = getTopLevelDeclarations(k!, (<any> obj)[k!]);
+                    decls.forEach(d => ns.members.push(d));
+                }
+                ns.members.sort(declarationComparer);
+                return [ns];
+            } else {
+                return [dom.create.const(name, simpleType)];
+            }
+        } else if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean') {
+            return [create.const(name, <dom.Type> (typeof obj))];
+        } else {
+            return [create.const(name, dom.type.any)];
+        }
+    }
 }
 
 function getTypeOfValue(value: any): dom.Type {
-	for (const k in builtins) {
-		if (builtins[k] && value instanceof builtins[k]!) {
-			return create.namedTypeReference(k);
-		}
-	}
+    for (const k in builtins) {
+        if (builtins[k] && value instanceof builtins[k]!) {
+            return create.namedTypeReference(k);
+        }
+    }
 
-	if (Array.isArray(value)) {
-		if (value.length > 0) {
-			return create.array(getTypeOfValue(value[0]));
-		} else {
-			return create.array(dom.type.any);
-		}
-	}
+    if (Array.isArray(value)) {
+        if (value.length > 0) {
+            return create.array(getTypeOfValue(value[0]));
+        } else {
+            return create.array(dom.type.any);
+        }
+    }
 
-	const type = typeof value;
-	switch (type) {
-		case 'string':
-		case 'number':
-		case 'boolean':
-			return type;
-		case 'undefined':
-			return dom.type.any;
-		case 'object':
-			if (value === null) {
-				return dom.type.any;
-			} else {
-				walkStack.add(value);
-				const members = getPropertyDeclarationsOfObject(value);
-				walkStack.delete(value);
-				members.sort(declarationComparer);
-				const objType = dom.create.objectType(members);
-				return objType;
-			}
-		default:
-			return dom.type.any;
-	}
+    const type = typeof value;
+    switch (type) {
+        case 'string':
+        case 'number':
+        case 'boolean':
+            return type;
+        case 'undefined':
+            return dom.type.any;
+        case 'object':
+            if (value === null) {
+                return dom.type.any;
+            } else {
+                walkStack.add(value);
+                const members = getPropertyDeclarationsOfObject(value);
+                walkStack.delete(value);
+                members.sort(declarationComparer);
+                const objType = dom.create.objectType(members);
+                return objType;
+            }
+        default:
+            return dom.type.any;
+    }
 }
 
 function getPropertyDeclarationsOfObject(obj: any): dom.ObjectTypeMember[] {
-	walkStack.add(obj);
-	const keys = getKeysOfObject(obj);
-	const result = keys.map(getProperty);
-	walkStack.delete(obj);
-	return result;
+    walkStack.add(obj);
+    const keys = getKeysOfObject(obj);
+    const result = keys.map(getProperty);
+    walkStack.delete(obj);
+    return result;
 
-	function getProperty(k: string) {
-		if (walkStack.has(obj[k])) {
-			return create.property(k, dom.type.any);
-		}
-		return create.property(k, getTypeOfValue(obj[k]));
-	}
+    function getProperty(k: string) {
+        if (walkStack.has(obj[k])) {
+            return create.property(k, dom.type.any);
+        }
+        return create.property(k, getTypeOfValue(obj[k]));
+    }
 }
 
 function getClassPrototypeMembers(ctor: any): dom.ClassMember[] {
-	const names = Object.getOwnPropertyNames(ctor.prototype);
-	const members = <dom.ClassMember[]> names
-		.filter(n => !isNameToSkip(n))
-		.map(name =>
-			getPrototypeMember(name, Object.getOwnPropertyDescriptor(ctor.prototype, name)!.value))
-		.filter(m => m !== undefined);
-	members.sort();
-	return members;
+    const names = Object.getOwnPropertyNames(ctor.prototype);
+    const members = <dom.ClassMember[]> names
+        .filter(n => !isNameToSkip(n))
+        .map(name =>
+            getPrototypeMember(name, Object.getOwnPropertyDescriptor(ctor.prototype, name)!.value))
+        .filter(m => m !== undefined);
+    members.sort();
+    return members;
 
-	function getPrototypeMember(name: string, obj: any): dom.ClassMember | undefined {
-		// Skip non-function objects on the prototype (not sure what to do with these?)
-		if (typeof obj !== 'function') {
-			return undefined;
-		}
+    function getPrototypeMember(name: string, obj: any): dom.ClassMember | undefined {
+        // Skip non-function objects on the prototype (not sure what to do with these?)
+        if (typeof obj !== 'function') {
+            return undefined;
+        }
 
-		const funcType = getParameterListAndReturnType(obj, parseFunctionBody(obj));
-		const result = create.method(name, funcType[0], funcType[1]);
-		if (isNativeFunction(obj)) {
-			result.comment = 'Native method; no parameter or return type inference available';
-		}
-		return result;
-	}
+        const funcType = getParameterListAndReturnType(obj, parseFunctionBody(obj));
+        const result = create.method(name, funcType[0], funcType[1]);
+        if (isNativeFunction(obj)) {
+            result.comment = 'Native method; no parameter or return type inference available';
+        }
+        return result;
+    }
 
-	function isNameToSkip(s: string) {
-		return (s === 'constructor') || (s[0] === '_');
-	}
+    function isNameToSkip(s: string) {
+        return (s === 'constructor') || (s[0] === '_');
+    }
 }
 
 function declarationComparer(left: any, right: any) {
-	if (left.kind === right.kind) {
-		return left.name > right.name ? 1 : left.name < right.name ? -1 : 0;
-	} else {
-		return left.kind > right.kind ? 1 : left.kind < right.kind ? -1 : 0;
-	}
+    if (left.kind === right.kind) {
+        return left.name > right.name ? 1 : left.name < right.name ? -1 : 0;
+    } else {
+        return left.kind > right.kind ? 1 : left.kind < right.kind ? -1 : 0;
+    }
 }
 
 function getParameterListAndReturnType(obj: Function, fn: ts.FunctionExpression): [dom.Parameter[], dom.Type] {
-	let usedArguments = false;
-	let hasReturn = false;
-	const funcStack: boolean[] = [];
+    let usedArguments = false;
+    let hasReturn = false;
+    const funcStack: boolean[] = [];
 
-	if (isNativeFunction(obj)) {
-		const args: dom.Parameter[] = [];
-		for (let i = 0; i < obj.length; i++) {
-			args.push(create.parameter(`p${i}`, dom.type.any));
-		}
-		return [args, dom.type.any];
-	} else {
-		ts.forEachChild(fn, visit);
+    if (isNativeFunction(obj)) {
+        const args: dom.Parameter[] = [];
+        for (let i = 0; i < obj.length; i++) {
+            args.push(create.parameter(`p${i}`, dom.type.any));
+        }
+        return [args, dom.type.any];
+    } else {
+        ts.forEachChild(fn, visit);
 
-		let params = [create.parameter('args', dom.type.array(dom.type.any), dom.ParameterFlags.Rest)];
-		if (fn.parameters) {
-			params = fn.parameters.map(p => create.parameter(`${p.name.getText()}`, inferParameterType(fn, p)));
-			if (usedArguments) {
-				params.push(create.parameter('args', dom.type.array(dom.type.any), dom.ParameterFlags.Rest));
-			}
-		}
-		return [params, hasReturn ? dom.type.any : dom.type.void];
-	}
+        let params = [create.parameter('args', dom.type.array(dom.type.any), dom.ParameterFlags.Rest)];
+        if (fn.parameters) {
+            params = fn.parameters.map(p => create.parameter(`${p.name.getText()}`, inferParameterType(fn, p)));
+            if (usedArguments) {
+                params.push(create.parameter('args', dom.type.array(dom.type.any), dom.ParameterFlags.Rest));
+            }
+        }
+        return [params, hasReturn ? dom.type.any : dom.type.void];
+    }
 
-	function visit(node: ts.Node) {
-		switch (node.kind) {
-			case ts.SyntaxKind.Identifier:
-				if ((node as ts.Identifier).getText() === 'arguments') {
-					usedArguments = true;
-				}
-				break;
-			case ts.SyntaxKind.ReturnStatement:
-				const ret = node as ts.ReturnStatement;
-				if (funcStack.length === 0 && ret.expression && ret.expression.kind !== ts.SyntaxKind.VoidExpression) {
-					hasReturn = true;
-				}
-		}
-		switch (node.kind) {
-			case ts.SyntaxKind.FunctionExpression:
-			case ts.SyntaxKind.FunctionDeclaration:
-				funcStack.push(true);
-				ts.forEachChild(node, visit);
-				funcStack.pop();
+    function visit(node: ts.Node) {
+        switch (node.kind) {
+            case ts.SyntaxKind.Identifier:
+                if ((node as ts.Identifier).getText() === 'arguments') {
+                    usedArguments = true;
+                }
+                break;
+            case ts.SyntaxKind.ReturnStatement:
+                const ret = node as ts.ReturnStatement;
+                if (funcStack.length === 0 && ret.expression && ret.expression.kind !== ts.SyntaxKind.VoidExpression) {
+                    hasReturn = true;
+                }
+        }
+        switch (node.kind) {
+            case ts.SyntaxKind.FunctionExpression:
+            case ts.SyntaxKind.FunctionDeclaration:
+                funcStack.push(true);
+                ts.forEachChild(node, visit);
+                funcStack.pop();
 
-			default:
-				ts.forEachChild(node, visit);
-				break;
-		}
-	}
+            default:
+                ts.forEachChild(node, visit);
+                break;
+        }
+    }
 
 }
 
 function inferParameterType(_fn: ts.FunctionExpression, _param: ts.ParameterDeclaration): dom.Type {
-	// TODO: Inspect function body for clues
-	return dom.type.any;
+    // TODO: Inspect function body for clues
+    return dom.type.any;
 }
 
 function parseFunctionBody(fn: any): ts.FunctionExpression {
-	const setup = `const myFn = ${fn.toString()};`;
-	const srcFile = ts.createSourceFile('test.ts', setup, ts.ScriptTarget.Latest, true);
-	const statement = srcFile.statements[0] as ts.VariableStatement;
-	const decl = statement.declarationList.declarations[0];
-	const init = decl.initializer as ts.FunctionExpression;
-	return init;
+    const setup = `const myFn = ${fn.toString()};`;
+    const srcFile = ts.createSourceFile('test.ts', setup, ts.ScriptTarget.Latest, true);
+    const statement = srcFile.statements[0] as ts.VariableStatement;
+    const decl = statement.declarationList.declarations[0];
+    const init = decl.initializer as ts.FunctionExpression;
+    return init;
 }
 
 function isNativeFunction(fn: any) {
-	return fn.toString().indexOf('{ [native code] }') > 0;
+    return fn.toString().indexOf('{ [native code] }') > 0;
 }

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -59,7 +59,8 @@ try {
     if (+!!args.dt + +!!args.file + +!!args.stdout > 1) {
         throw new ArgsError('Cannot specify more than one output mode');
     }
-    if (+!!args.identifier + +!!args.expression + +!!args.module + +!!args['expression-file'] + +!!args.template !== 1) {
+    if (+!!args.identifier + +!!args.expression + +!!args.module + +!!args['expression-file'] + +!!args.template
+        !== 1) {
         throw new ArgsError('Must specify exactly one input');
     }
     if (typeof args.name === 'boolean') throw new ArgsError('Must specify a value for "-name"');
@@ -103,12 +104,8 @@ try {
     } else if (args.stdout) {
         console.log(result);
     } else {
-        let filename: string;
-        if (typeof args.file === 'boolean' || args.file === undefined) {
-            filename = name + '.d.ts';
-        } else {
-            filename = args.file;
-        }
+        let filename =
+            typeof args.file === 'boolean' || args.file === undefined ? name + '.d.ts' : args.file;
         if (!filename.endsWith('.d.ts')) {
             filename = filename + '.d.ts';
         }

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -10,166 +10,166 @@ import writeDefinitelyTypedPackage from './definitely-typed';
 const templatesDirectory = path.join(__dirname, "..", "..", "templates");
 
 interface Options {
-	module?: string;
-	expression?: string;
-	'expression-file': string;
-	identifier?: string;
-	template?: string;
+    module?: string;
+    expression?: string;
+    'expression-file': string;
+    identifier?: string;
+    template?: string;
 
-	name?: string;
+    name?: string;
 
-	file?: string | boolean;
-	dt?: string | boolean;
-	stdout?: boolean;
-	overwrite?: boolean;
+    file?: string | boolean;
+    dt?: string | boolean;
+    stdout?: boolean;
+    overwrite?: boolean;
 
-	version?: boolean;
+    version?: boolean;
 }
 
 const args = yargs
-	.alias('m', 'module')
-	.alias('i', 'identifier')
-	.alias('e', 'expression')
-	.alias('n', 'name')
-	.alias('f', 'file')
-	.alias('d', 'dt')
-	.alias('s', 'stdout')
-	.alias('o', 'overwrite')
-	.alias('t', 'template')
-	.alias('v', 'version')
-	.argv as any as Options;
+    .alias('m', 'module')
+    .alias('i', 'identifier')
+    .alias('e', 'expression')
+    .alias('n', 'name')
+    .alias('f', 'file')
+    .alias('d', 'dt')
+    .alias('s', 'stdout')
+    .alias('o', 'overwrite')
+    .alias('t', 'template')
+    .alias('v', 'version')
+    .argv as any as Options;
 
 class ArgsError extends Error {
-	constructor(public argsError: string) {
-		super();
-		this.name = 'ArgsError';
-		this.message = argsError;
+    constructor(public argsError: string) {
+        super();
+        this.name = 'ArgsError';
+        this.message = argsError;
 
-		Object.setPrototypeOf(this, ArgsError.prototype);
-	}
+        Object.setPrototypeOf(this, ArgsError.prototype);
+    }
 }
 
 let result: string | undefined;
 try {
-	if (args.version) {
-		console.log(require("../../package.json").version);
-		process.exit(0);
-	}
+    if (args.version) {
+        console.log(require("../../package.json").version);
+        process.exit(0);
+    }
 
-	if (+!!args.dt + +!!args.file + +!!args.stdout > 1) {
-		throw new ArgsError('Cannot specify more than one output mode');
-	}
-	if (+!!args.identifier + +!!args.expression + +!!args.module + +!!args['expression-file'] + +!!args.template !== 1) {
-		throw new ArgsError('Must specify exactly one input');
-	}
-	if (typeof args.name === 'boolean') throw new ArgsError('Must specify a value for "-name"');
-	if (typeof args.identifier === 'boolean') throw new ArgsError('Must specify a value for "-identifier"');
-	if (typeof args.module === 'boolean') throw new ArgsError('Must specify a value for "-module"');
-	if (args.overwrite !== undefined && args.overwrite !== true)
-		throw new ArgsError('-overwrite does not accept an argument');
+    if (+!!args.dt + +!!args.file + +!!args.stdout > 1) {
+        throw new ArgsError('Cannot specify more than one output mode');
+    }
+    if (+!!args.identifier + +!!args.expression + +!!args.module + +!!args['expression-file'] + +!!args.template !== 1) {
+        throw new ArgsError('Must specify exactly one input');
+    }
+    if (typeof args.name === 'boolean') throw new ArgsError('Must specify a value for "-name"');
+    if (typeof args.identifier === 'boolean') throw new ArgsError('Must specify a value for "-identifier"');
+    if (typeof args.module === 'boolean') throw new ArgsError('Must specify a value for "-module"');
+    if (args.overwrite !== undefined && args.overwrite !== true)
+        throw new ArgsError('-overwrite does not accept an argument');
 
-	let name: string;
-	if (args.module) {
-		if (args.name) throw new ArgsError('Cannot use -name with -module');
-		name = args.module;
-		(module as any).paths.unshift(process.cwd() + '/node_modules');
-		result = guess.generateModuleDeclarationFile(args.module, require(args.module));
-	} else if (args.expression) {
-		name = args.name || 'dts_gen_expr';
-		result = guess.generateIdentifierDeclarationFile(name, eval(args.expression));
-	} else if (args['expression-file']) {
-		if (args.name) throw new ArgsError('Cannot use -name with -expression-file');
-		const filename = args['expression-file'];
-		name = path.basename(filename, path.extname(filename)).replace(/[^A-Za-z0-9]/g, '_');
-		(module as any).paths.unshift(process.cwd() + '/node_modules');
-		const fileContent = fs.readFileSync(filename, "utf-8");
-		result = guess.generateIdentifierDeclarationFile(name, eval(fileContent));
-	} else if (args.identifier) {
-		if (args.name) throw new ArgsError('Cannot use -name with -identifier');
-		if (args.module || args.expression) throw new ArgsError('Cannot specify more than one input');
-		name = args.identifier;
-		result = guess.generateIdentifierDeclarationFile(args.identifier, eval(args.identifier));
-	} else if (args.template) {
-		if (!args.name) throw new ArgsError('Needs a name');
-		name = args.name;
-		if (args.module || args.expression) throw new ArgsError('Cannot mix -template with -module or -expression');
-		result = getTemplate(args.template);
-	} else {
-		throw new Error('Internal error, please log a bug with the commandline you specified');
-	}
+    let name: string;
+    if (args.module) {
+        if (args.name) throw new ArgsError('Cannot use -name with -module');
+        name = args.module;
+        (module as any).paths.unshift(process.cwd() + '/node_modules');
+        result = guess.generateModuleDeclarationFile(args.module, require(args.module));
+    } else if (args.expression) {
+        name = args.name || 'dts_gen_expr';
+        result = guess.generateIdentifierDeclarationFile(name, eval(args.expression));
+    } else if (args['expression-file']) {
+        if (args.name) throw new ArgsError('Cannot use -name with -expression-file');
+        const filename = args['expression-file'];
+        name = path.basename(filename, path.extname(filename)).replace(/[^A-Za-z0-9]/g, '_');
+        (module as any).paths.unshift(process.cwd() + '/node_modules');
+        const fileContent = fs.readFileSync(filename, "utf-8");
+        result = guess.generateIdentifierDeclarationFile(name, eval(fileContent));
+    } else if (args.identifier) {
+        if (args.name) throw new ArgsError('Cannot use -name with -identifier');
+        if (args.module || args.expression) throw new ArgsError('Cannot specify more than one input');
+        name = args.identifier;
+        result = guess.generateIdentifierDeclarationFile(args.identifier, eval(args.identifier));
+    } else if (args.template) {
+        if (!args.name) throw new ArgsError('Needs a name');
+        name = args.name;
+        if (args.module || args.expression) throw new ArgsError('Cannot mix -template with -module or -expression');
+        result = getTemplate(args.template);
+    } else {
+        throw new Error('Internal error, please log a bug with the commandline you specified');
+    }
 
-	if (args.dt) {
-		writeDefinitelyTypedPackage(result, name, !!args.overwrite);
-	} else if (args.stdout) {
-		console.log(result);
-	} else {
-		let filename: string;
-		if (typeof args.file === 'boolean' || args.file === undefined) {
-			filename = name + '.d.ts';
-		} else {
-			filename = args.file;
-		}
-		if (!filename.endsWith('.d.ts')) {
-			filename = filename + '.d.ts';
-		}
+    if (args.dt) {
+        writeDefinitelyTypedPackage(result, name, !!args.overwrite);
+    } else if (args.stdout) {
+        console.log(result);
+    } else {
+        let filename: string;
+        if (typeof args.file === 'boolean' || args.file === undefined) {
+            filename = name + '.d.ts';
+        } else {
+            filename = args.file;
+        }
+        if (!filename.endsWith('.d.ts')) {
+            filename = filename + '.d.ts';
+        }
 
-		if (!args.overwrite && fs.existsSync(filename)) {
-			console.error(`File ${filename} already exists and -overwrite was not specified; exiting.`);
-			process.exit(2);
-		}
-		fs.writeFileSync(filename, prependOurHeader(result), 'utf-8');
-		console.log(`Wrote ${result.split(/\r\n|\r|\n/).length} lines to ${filename}.`);
-	}
+        if (!args.overwrite && fs.existsSync(filename)) {
+            console.error(`File ${filename} already exists and -overwrite was not specified; exiting.`);
+            process.exit(2);
+        }
+        fs.writeFileSync(filename, prependOurHeader(result), 'utf-8');
+        console.log(`Wrote ${result.split(/\r\n|\r|\n/).length} lines to ${filename}.`);
+    }
 } catch (e) {
-	if (e instanceof ArgsError) {
-		console.error('Invalid arguments: ' + e.argsError);
-		console.log('');
-		printHelp();
-		process.exit(1);
-	} else if (e.code === 'MODULE_NOT_FOUND') {
-		console.log(`Couldn't load module "${args.module}". ` +
-			`Please install it globally (npm install -g ${args.module}) and try again.`);
-		process.exit(1);
-	} else {
-		console.log('Unexpected crash! Please log a bug with the commandline you specified.');
-		throw e;
-	}
+    if (e instanceof ArgsError) {
+        console.error('Invalid arguments: ' + e.argsError);
+        console.log('');
+        printHelp();
+        process.exit(1);
+    } else if (e.code === 'MODULE_NOT_FOUND') {
+        console.log(`Couldn't load module "${args.module}". ` +
+            `Please install it globally (npm install -g ${args.module}) and try again.`);
+        process.exit(1);
+    } else {
+        console.log('Unexpected crash! Please log a bug with the commandline you specified.');
+        throw e;
+    }
 }
 
 function printHelp() {
-	console.log('Usage: dts-gen input [settings] [output]');
-	console.log('');
-	console.log('Input Options:');
-	console.log('  -m[odule] fs            The "fs" node module (must be installed)');
-	console.log('  -i[dentifier] Math      The global variable "Math"');
-	console.log('  -e[xpression] "new C()" The expression "new C()"');
-	console.log('  -t[emplate] module      Name of a template. Templates are:');
-	console.log(`                          ${allTemplateNames()}`);
-	console.log('');
-	console.log('Settings:');
-	console.log('  -n[ame] n               The name to emit when generating for an expression');
-	console.log('');
-	console.log('Output Options:');
-	console.log('  -f[ile] [filename.d.ts]  Write to a file (default)');
-	console.log('  -d[t] [dirName]          Create a folder suitable for DefinitelyTyped');
-	console.log('  -s[tdout]                Write to stdout');
-	console.log('  -o[verwrite]             Allow overwriting files');
-	console.log('');
-	console.log('Example: dts-gen -m fs --stdout');
+    console.log('Usage: dts-gen input [settings] [output]');
+    console.log('');
+    console.log('Input Options:');
+    console.log('  -m[odule] fs            The "fs" node module (must be installed)');
+    console.log('  -i[dentifier] Math      The global variable "Math"');
+    console.log('  -e[xpression] "new C()" The expression "new C()"');
+    console.log('  -t[emplate] module      Name of a template. Templates are:');
+    console.log(`                          ${allTemplateNames()}`);
+    console.log('');
+    console.log('Settings:');
+    console.log('  -n[ame] n               The name to emit when generating for an expression');
+    console.log('');
+    console.log('Output Options:');
+    console.log('  -f[ile] [filename.d.ts]  Write to a file (default)');
+    console.log('  -d[t] [dirName]          Create a folder suitable for DefinitelyTyped');
+    console.log('  -s[tdout]                Write to stdout');
+    console.log('  -o[verwrite]             Allow overwriting files');
+    console.log('');
+    console.log('Example: dts-gen -m fs --stdout');
 }
 
 function prependOurHeader(result: string) {
-	return `/** Declaration file generated by dts-gen */\r\n\r\n` + result;
+    return `/** Declaration file generated by dts-gen */\r\n\r\n` + result;
 }
 
 function getTemplate(templateName: string): string {
-	try {
-	return fs.readFileSync(path.join(templatesDirectory, templateName + ".d.ts"), "utf-8");
-	} catch (e) {
-		throw new ArgsError(`Could not read template '${templateName}'. Expected one of:\n${allTemplateNames()}`);
-	}
+    try {
+    return fs.readFileSync(path.join(templatesDirectory, templateName + ".d.ts"), "utf-8");
+    } catch (e) {
+        throw new ArgsError(`Could not read template '${templateName}'. Expected one of:\n${allTemplateNames()}`);
+    }
 }
 
 function allTemplateNames(): string {
-	return fs.readdirSync(templatesDirectory).map(t => t.slice(0, t.length - ".d.ts".length)).join(", ");
+    return fs.readdirSync(templatesDirectory).map(t => t.slice(0, t.length - ".d.ts".length)).join(", ");
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "mocha bin/tests/test.js",
     "build": "tsc",
     "build-browser": "tsc -p browser && webpack",
-    "lint": "tslint --type-check --project tsconfig.json --format stylish"
+    "lint": "tslint --project tsconfig.json --format stylish"
   },
   "repository": {
     "type": "git",

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -4,62 +4,62 @@ import * as path from 'path';
 import * as tsg from '../lib';
 
 const testModuleNames = [
-	'fs',
-	'path',
-	'lodash',
-	'jquery',
-	'yargs',
-	'ecurve',
+    'fs',
+    'path',
+    'lodash',
+    'jquery',
+    'yargs',
+    'ecurve',
 ];
 
 class MyClass {
-	constructor(public arg: number) {
+    constructor(public arg: number) {
 
-	}
-	prototypeMethod(_p: any) { }
-	static staticMethod(_s: any) { }
-	static staticNum = 32;
-	instanceStr = 'inst';
+    }
+    prototypeMethod(_p: any) { }
+    static staticMethod(_s: any) { }
+    static staticNum = 32;
+    instanceStr = 'inst';
 }
 const selfRefExpr = {
-	a: 32,
-	b: 'ok',
-	self: <any> null,
+    a: 32,
+    b: 'ok',
+    self: <any> null,
 };
 selfRefExpr.self = selfRefExpr;
 
 const expressions: { [s: string]: any } = {
-	Math,
-	selfref: selfRefExpr,
-	builtIns: { d: new Date(3), arr: ['x']},
-	someArray: [ 1, 'foo', Math, null, undefined, false ],
-	badNames: { "*": 10, "default": true, "with": 10, "  ": 3 },
-	someClass: MyClass,
+    Math,
+    selfref: selfRefExpr,
+    builtIns: { d: new Date(3), arr: ['x']},
+    someArray: [ 1, 'foo', Math, null, undefined, false ],
+    badNames: { "*": 10, "default": true, "with": 10, "  ": 3 },
+    someClass: MyClass,
 };
 
 function checkDeclarationBaseline(name: string, content: string) {
-	const filename = path.join(__dirname, `../../baselines/${name}`);
-	const existing = fs.existsSync(filename) ? fs.readFileSync(filename, 'utf-8') : '<none>';
-	if (existing !== content) {
-		fs.writeFileSync(filename, content, 'utf-8');
-		throw new Error(`Baseline ${name} changed`);
-	}
+    const filename = path.join(__dirname, `../../baselines/${name}`);
+    const existing = fs.existsSync(filename) ? fs.readFileSync(filename, 'utf-8') : '<none>';
+    if (existing !== content) {
+        fs.writeFileSync(filename, content, 'utf-8');
+        throw new Error(`Baseline ${name} changed`);
+    }
 }
 
 describe("Module tests", () => {
-	for (const moduleName of testModuleNames) {
-		it(`Generates the same declaration for ${moduleName}`, () => {
-			const result = tsg.generateModuleDeclarationFile(moduleName!, require(moduleName!));
-			checkDeclarationBaseline(`module-${moduleName}.d.ts`, result);
-		});
-	}
+    for (const moduleName of testModuleNames) {
+        it(`Generates the same declaration for ${moduleName}`, () => {
+            const result = tsg.generateModuleDeclarationFile(moduleName!, require(moduleName!));
+            checkDeclarationBaseline(`module-${moduleName}.d.ts`, result);
+        });
+    }
 });
 
 describe("Expression tests", () => {
-	for (const key of Object.keys(expressions)) {
-		it(`Generates the same declaration for ${key}`, () => {
-			const result = tsg.generateIdentifierDeclarationFile(key!, expressions[key!]);
-			checkDeclarationBaseline(`expr-${key}.d.ts`, result);
-		});
-	}
+    for (const key of Object.keys(expressions)) {
+        it(`Generates the same declaration for ${key}`, () => {
+            const result = tsg.generateIdentifierDeclarationFile(key!, expressions[key!]);
+            checkDeclarationBaseline(`expr-${key}.d.ts`, result);
+        });
+    }
 });

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,7 @@
         "ban-types": false,
         "curly": false,
         "member-ordering": false,
+        "no-duplicate-imports": false,
         "no-angle-bracket-type-assertion": false,
         "no-bitwise": false,
         "no-console": false,

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,7 @@
     "extends": "tslint:latest",
     "rules": {
         "arrow-parens": [true, "ban-single-arg-parens"],
-        "indent": [true, "tabs"],
+        "indent": [true, "spaces"],
         "interface-name": [true, "never-prefix"],
         "member-access": [true, "no-public"],
 


### PR DESCRIPTION
1. Update some config files and fix lint.
2. Convert tabs to spaces.
3. Update baselines with dts-dom's new double-spaced format and fs' many new features.

You should view this PR ignoring whitespace.