### PR TITLE
Fix generation of module "node-blockly"

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -117,7 +117,7 @@ function isLegalIdentifier(s: string) {
 }
 
 function isClasslike(obj: { prototype: any }): boolean {
-    return !!(obj.prototype && Object.getOwnPropertyNames(obj.prototype).length > 1);
+    return !!(obj && obj.prototype && Object.getOwnPropertyNames(obj.prototype).length > 1);
 }
 
 const keyStack: string[] = [];


### PR DESCRIPTION
When trying to build `node-blockly`, the following error occurs: 

```
TypeError: Cannot read property 'prototype' of null
    at isClasslike (index.js:109:19)
    at Array.some (<anonymous>)
    at hasCloduleProperties (index.js:42:31)
    at getValueTypes (index.js:30:37)
    at getResult (index.js:187:55)
    at getTopLevelDeclarations (index.js:124:17)      
    at Object.generateModuleDeclarationFile (index.js:50:19)
    at Object.<anonymous> (run.js:58:24)
    at Module._compile (loader.js:1144:30)
```

This PR fixes that issue.

I have no clue what could be causing this, I just added a null check on `obj`.