### PR TITLE
Improved error logging in case when the user specified module can not be loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-node_modules/
-bin/
-npm-debug.log
+.idea/
 .vscode/
+bin/
+node_modules/
 
+npm-debug.log

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -124,8 +124,9 @@ try {
         printHelp();
         process.exit(1);
     } else if (e.code === 'MODULE_NOT_FOUND') {
-        console.log(`Couldn't load module "${args.module}". ` +
-            `Please install it globally (npm install -g ${args.module}) and try again.`);
+        console.error(`Error loading module "${args.module}".\n` +
+          getErrorMessageFirstLine(e).replace(/'/g, '"') + '.\n' +
+          `Please install missing module and try again.`);
         process.exit(1);
     } else {
         console.log('Unexpected crash! Please log a bug with the commandline you specified.');
@@ -169,4 +170,8 @@ function getTemplate(templateName: string): string {
 
 function allTemplateNames(): string {
     return fs.readdirSync(templatesDirectory).map(t => t.slice(0, t.length - ".d.ts".length)).join(", ");
+}
+
+function getErrorMessageFirstLine(error: Error): string {
+    return error.message.split('\n', 1)[0];
 }


### PR DESCRIPTION
Right now, `dts-gen` tries to load the user specified module and looks for `MODULE_NOT_FOUND` errors. When such error is caught it instruct the user to install the specified module (thinking that the specified module is not actually installed).

However, in situations where the specified module can't be correctly loaded due to the missing dependency, the error message becomes wrong: it suggests to install the specified module, however it is already installed.

This PR makes the error message more clear by telling exactly what dependency failed to load and suggests to install it.

This should correctly fix #86, which was closed without a proper fix.