### PR TITLE
Avoid crash on overridden `fn.toString(…)`

### DIFF
--- a/baselines/expr-overriddenToString.d.ts
+++ b/baselines/expr-overriddenToString.d.ts
@@ -1,0 +1,7 @@
+declare function overriddenToString(): void;
+
+
+declare namespace overriddenToString {
+    function toString(): void;
+
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -368,8 +368,10 @@ function inferParameterType(_fn: ts.FunctionExpression, _param: ts.ParameterDecl
     return dom.type.any;
 }
 
+const stringifyFunction: (fn: Function) => string = Function.prototype.call.bind(Function.prototype.toString);
+
 function parseFunctionBody(fn: any): ts.FunctionExpression {
-    const setup = `const myFn = ${fn.toString()};`;
+    const setup = `const myFn = ${stringifyFunction(fn)};`;
     const srcFile = ts.createSourceFile('test.ts', setup, ts.ScriptTarget.Latest, true);
     const statement = srcFile.statements[0] as ts.VariableStatement;
     const decl = statement.declarationList.declarations[0];
@@ -378,5 +380,5 @@ function parseFunctionBody(fn: any): ts.FunctionExpression {
 }
 
 function isNativeFunction(fn: any) {
-    return fn.toString().indexOf('{ [native code] }') > 0;
+    return stringifyFunction(fn).indexOf('{ [native code] }') > 0;
 }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -21,6 +21,12 @@ class MyClass {
     static staticNum = 32;
     instanceStr = 'inst';
 }
+
+function overriddenToString() {}
+overriddenToString.toString = () => {
+    throw new Error('`fn.toString()` should not be called');
+};
+
 const selfRefExpr = {
     a: 32,
     b: 'ok',
@@ -35,6 +41,7 @@ const expressions: { [s: string]: any } = {
     someArray: [ 1, 'foo', Math, null, undefined, false ],
     badNames: { "*": 10, "default": true, "with": 10, "  ": 3 },
     someClass: MyClass,
+    overriddenToString,
 };
 
 function checkDeclarationBaseline(name: string, content: string) {


### PR DESCRIPTION
If a function has an overridden `toString` property, then `dts‑gen` ends up crashing, as the output no longer matches what `dts‑gen` expects.

This fixes that by always calling the original `Function.prototype.toString` method.

---

Fixes <https://github.com/microsoft/dts-gen/issues/145>