### PR TITLE
fix: update TSLint template to align with DT changes

### DIFF
--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -34,7 +34,7 @@ async function run(indexDtsContent: string, packageName: string, dtName: string,
         ["index.d.ts", await getIndex(indexDtsContent, packageName)],
         [`${dtName}-tests.ts`, ""],
         ["tsconfig.json", `${JSON.stringify(getTSConfig(dtName), undefined, 4)}\n`],
-        ["tslint.json", '{ "extends": "dtslint/dt.json" }\n'],
+        ["tslint.json", '{ "extends": "@definitelytyped/dtslint/dt.json" }\n'],
     ];
 
     for (const [name, text] of files) {


### PR DESCRIPTION
On DT all definitions have been mass migrated to use
'"@definitelytyped/dtslint/dt.json"' as a value. But this is not a case
for newly created DT definitions when using recommended in README
`dts-gen ....` command.

Thanks!

See: DefinitelyTyped/DefinitelyTyped#57489