### PR TITLE
Fix import of STATUS_CODES in definitely-typed.ts

### DIFF
--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
-import { get, STATUS_CODES } from "https";
+import { STATUS_CODES } from 'http';
+import { get } from "https";
 import { homedir } from 'os';
 import parseGitConfig = require('parse-git-config');
 import { join as joinPaths } from "path";


### PR DESCRIPTION
The node package ```https``` has no exported member ```STATUS_CODES```, its exported only in ```http``` package. This pull request fixes it.

References:
https://nodejs.org/api/https.html
https://nodejs.org/api/http.html#httpstatus_codes