### PR TITLE
Use owners, not contributors

### DIFF
--- a/lib/definitely-typed.ts
+++ b/lib/definitely-typed.ts
@@ -113,7 +113,7 @@ async function getPackageJson(dtName: string, packageName: string): Promise<{}> 
         devDependencies: {
             [`@types/${dtName}`]: "workspace:."
         },
-        contributors: [
+        owners: [
             {
                 name: authorName,
                 githubUsername: authorUserName


### PR DESCRIPTION
I forgot to change this when we renamed it on the main branch.